### PR TITLE
feat: Add 'Week of the Year' arc and separator lines

### DIFF
--- a/index.html
+++ b/index.html
@@ -637,6 +637,13 @@
                         <span class="slider"></span>
                     </label>
                 </div>
+                <div class="setting-toggle">
+                    <span>Show Week Bar</span>
+                    <label class="switch">
+                        <input type="checkbox" id="weekBarToggle">
+                        <span class="slider"></span>
+                    </label>
+                </div>
             </div>
             <div class="settings-section">
                 <h3>Audio</h3>
@@ -775,8 +782,8 @@ document.addEventListener('DOMContentLoaded', function() {
             const textX = dimensions.centerX;
             const textY = dimensions.centerY + arc.radius;
 
-            let fontSizeMultiplier = (arc.key === 'month') ? 0.8 : 0.6;
-            let circleSizeMultiplier = (arc.key === 'month') ? 0.85 : 0.7;
+            let fontSizeMultiplier = (arc.key === 'month' || arc.key === 'week') ? 0.8 : 0.6;
+            let circleSizeMultiplier = (arc.key === 'month' || arc.key === 'week') ? 0.85 : 0.7;
             if (settings.labelDisplayMode === 'percentage') fontSizeMultiplier *= 0.85;
 
             const circleRadius = arc.lineWidth * circleSizeMultiplier;
@@ -796,7 +803,44 @@ document.addEventListener('DOMContentLoaded', function() {
             ctx.fillText(arc.text, textX, textY);
         };
 
+        const drawSeparators = (radius, count, arcLineWidth) => {
+            if (!radius || radius <= 0) return;
+
+            const innerRadius = radius - (arcLineWidth / 2);
+            const outerRadius = radius + (arcLineWidth / 2);
+            const sixOClockAngle = baseStartAngle + Math.PI;
+
+            ctx.strokeStyle = '#121212'; // Background color for "cutout" effect
+            ctx.lineWidth = 2; // Separator line width
+
+            for (let i = 0; i < count; i++) {
+                const angle = baseStartAngle + (i / count) * Math.PI * 2;
+
+                // Skip the 6 o'clock position with a small tolerance
+                if (Math.abs(angle - sixOClockAngle) < 0.01) {
+                    continue;
+                }
+
+                const startX = dimensions.centerX + Math.cos(angle) * innerRadius;
+                const startY = dimensions.centerY + Math.sin(angle) * innerRadius;
+                const endX = dimensions.centerX + Math.cos(angle) * outerRadius;
+                const endY = dimensions.centerY + Math.sin(angle) * outerRadius;
+
+                ctx.beginPath();
+                ctx.moveTo(startX, startY);
+                ctx.lineTo(endX, endY);
+                ctx.stroke();
+            }
+        };
+
         const getDaysInMonth = (year, month) => new Date(year, month + 1, 0).getDate();
+        const getWeekOfYear = (date) => {
+            const start = new Date(date.getFullYear(), 0, 1);
+            const diff = (date - start) + ((start.getTimezoneOffset() - date.getTimezoneOffset()) * 60 * 1000);
+            const oneDay = 1000 * 60 * 60 * 24;
+            const day = Math.floor(diff / oneDay);
+            return Math.ceil(day / 7);
+        };
 
         const getLabelText = (unit, now) => {
             const year = now.getFullYear(), month = now.getMonth(), date = now.getDate(), hours = now.getHours(), minutes = now.getMinutes(), seconds = now.getSeconds(), milliseconds = now.getMilliseconds();
@@ -812,6 +856,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     if (unit === 'hours') percent = ((hours % 12) * 3600000 + minutes * 60000 + seconds * 1000 + milliseconds) / 43200000 * 100;
                     if (unit === 'day') percent = ((date - 1) * totalMsInDay + currentMsInDay) / (daysInMonth * totalMsInDay) * 100;
                     if (unit === 'month') percent = (month + ((date - 1) * totalMsInDay + currentMsInDay) / (daysInMonth * totalMsInDay)) / 12 * 100;
+                    if (unit === 'week') percent = (getWeekOfYear(now) / 52) * 100;
                     return `${Math.floor(percent)}%`;
                 case 'remainder':
                     if (unit === 'seconds') return 59 - seconds;
@@ -819,6 +864,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     if (unit === 'hours') return 11 - (hours % 12);
                     if (unit === 'day') return daysInMonth - date;
                     if (unit === 'month') return 11 - month;
+                    if (unit === 'week') return 52 - getWeekOfYear(now);
                     return '';
                 default: // standard
                     if (unit === 'seconds') return seconds.toString().padStart(2, '0');
@@ -832,6 +878,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     }
                     if (unit === 'day') return date.toString();
                     if (unit === 'month') return (month + 1).toString().padStart(2, '0');
+                    if (unit === 'week') return getWeekOfYear(now);
                     return '';
             }
         };
@@ -844,14 +891,20 @@ document.addEventListener('DOMContentLoaded', function() {
             const now = new Date();
             const year = now.getFullYear(), month = now.getMonth(), date = now.getDate(), hours = now.getHours(), minutes = now.getMinutes(), seconds = now.getSeconds();
             const daysInMonth = getDaysInMonth(year, month);
+            const weekOfYear = getWeekOfYear(now);
 
             const monthEndAngle = baseStartAngle + ((month + date / daysInMonth) / 12) * Math.PI * 2;
             const dayEndAngle = baseStartAngle + ((date - 1 + (hours + minutes / 60) / 24) / daysInMonth) * Math.PI * 2;
+            const weekEndAngle = baseStartAngle + (weekOfYear / 52) * Math.PI * 2;
             const hoursEndAngle = baseStartAngle + (((hours % 12) + minutes / 60) / 12) * Math.PI * 2;
             const minutesEndAngle = baseStartAngle + ((minutes + seconds / 60) / 60) * Math.PI * 2;
             const secondsEndAngle = baseStartAngle + ((seconds + now.getMilliseconds() / 1000) / 60) * Math.PI * 2;
 
             const arcs = [];
+
+            if (settings.showWeekBar) {
+                arcs.push({ key: 'week', radius: dimensions.weekRadius, colors: settings.currentColors.week, lineWidth: 15, endAngle: weekEndAngle });
+            }
 
             if (settings.showDateLines) {
                 arcs.push({ key: 'month', radius: dimensions.monthRadius, colors: settings.currentColors.month, lineWidth: 20, endAngle: monthEndAngle });
@@ -877,6 +930,18 @@ document.addEventListener('DOMContentLoaded', function() {
                     drawLabel(arc);
                 }
             });
+
+            // --- Draw Separators ---
+            if (settings.showTimeLines) {
+                drawSeparators(dimensions.hoursRadius, 12, dimensions.hoursLineWidth);
+            }
+            if (settings.showDateLines) {
+                drawSeparators(dimensions.monthRadius, 12, dimensions.monthLineWidth);
+                drawSeparators(dimensions.dayRadius, daysInMonth, dimensions.dayLineWidth);
+            }
+            if (settings.showWeekBar) {
+                drawSeparators(dimensions.weekRadius, 52, dimensions.weekLineWidth);
+            }
 
             lastNow = now;
 
@@ -952,26 +1017,41 @@ document.addEventListener('DOMContentLoaded', function() {
                 dimensions.centerY = canvas.height / 2;
 
                 const baseRadius = Math.min(dimensions.centerX, dimensions.centerY) * 0.9;
-                const monthLineWidth = 20, dayLineWidth = 30, hourLineWidth = 45, minuteLineWidth = 30, secondLineWidth = 30, timerLineWidth = 30, alarmLineWidth = 20, gap = 15;
+                const monthLineWidth = 20, dayLineWidth = 30, hourLineWidth = 45, minuteLineWidth = 30, secondLineWidth = 30, timerLineWidth = 30, alarmLineWidth = 20, weekLineWidth = 15, gap = 15;
 
                 let totalWidth = secondLineWidth / 2 + minuteLineWidth + gap;
                 if (settings.showTimeLines) totalWidth += hourLineWidth + gap;
                 if (settings.showDateLines) totalWidth += dayLineWidth + gap + monthLineWidth + gap;
+                if (settings.showWeekBar) totalWidth += weekLineWidth + gap;
                 if (globalState.timer && globalState.timer.totalSeconds > 0) totalWidth += timerLineWidth + gap;
                 if (globalState.trackedAlarm && globalState.trackedAlarm.nextAlarmTime) totalWidth += alarmLineWidth + gap;
 
                 const scale = baseRadius / totalWidth;
                 let currentRadius = baseRadius;
 
-                dimensions.secondsRadius = currentRadius - (secondLineWidth / 2) * scale;
-                currentRadius -= (secondLineWidth + gap) * scale;
-                dimensions.minutesRadius = currentRadius - (minuteLineWidth / 2) * scale;
-                currentRadius -= (minuteLineWidth + gap) * scale;
-                dimensions.hoursRadius = settings.showTimeLines ? currentRadius - (hourLineWidth / 2) * scale : 0;
-                if (settings.showTimeLines) currentRadius -= (hourLineWidth + gap) * scale;
-                dimensions.dayRadius = settings.showDateLines ? currentRadius - (dayLineWidth / 2) * scale : 0;
-                if (settings.showDateLines) currentRadius -= (dayLineWidth + gap) * scale;
-                dimensions.monthRadius = settings.showDateLines ? currentRadius - (monthLineWidth / 2) * scale : 0;
+                dimensions.secondsLineWidth = secondLineWidth * scale;
+                dimensions.secondsRadius = currentRadius - (dimensions.secondsLineWidth / 2);
+                currentRadius -= (dimensions.secondsLineWidth + gap * scale);
+
+                dimensions.minutesLineWidth = minuteLineWidth * scale;
+                dimensions.minutesRadius = currentRadius - (dimensions.minutesLineWidth / 2);
+                currentRadius -= (dimensions.minutesLineWidth + gap * scale);
+
+                dimensions.hoursLineWidth = settings.showTimeLines ? hourLineWidth * scale : 0;
+                dimensions.hoursRadius = settings.showTimeLines ? currentRadius - (dimensions.hoursLineWidth / 2) : 0;
+                if (settings.showTimeLines) currentRadius -= (dimensions.hoursLineWidth + gap * scale);
+
+                dimensions.dayLineWidth = settings.showDateLines ? dayLineWidth * scale : 0;
+                dimensions.dayRadius = settings.showDateLines ? currentRadius - (dimensions.dayLineWidth / 2) : 0;
+                if (settings.showDateLines) currentRadius -= (dimensions.dayLineWidth + gap * scale);
+
+                dimensions.monthLineWidth = settings.showDateLines ? monthLineWidth * scale : 0;
+                dimensions.monthRadius = settings.showDateLines ? currentRadius - (dimensions.monthLineWidth / 2) : 0;
+                if (settings.showDateLines) currentRadius -= (dimensions.monthLineWidth + gap * scale);
+
+                dimensions.weekLineWidth = settings.showWeekBar ? weekLineWidth * scale : 0;
+                dimensions.weekRadius = settings.showWeekBar ? currentRadius - (dimensions.weekLineWidth / 2) : 0;
+                if (settings.showWeekBar) currentRadius -= (dimensions.weekLineWidth + gap * scale);
             },
             update: function(newSettings, newState) {
                 settings = newSettings;
@@ -1209,10 +1289,10 @@ document.addEventListener('DOMContentLoaded', function() {
         };
 
         const colorPalettes = {
-            default: { month: { light: '#D05CE3', dark: '#4A0055' }, day: { light: '#81C784', dark: '#003D00' }, hours: { light: '#FF9E80', dark: '#8C1C00' }, minutes: { light: '#FFF176', dark: '#B45F06' }, seconds: { light: '#81D4FA', dark: '#002E5C' } },
-            neon: { month: { light: '#ff00ff', dark: '#800080' }, day: { light: '#00ff00', dark: '#008000' }, hours: { light: '#ff0000', dark: '#800000' }, minutes: { light: '#ffff00', dark: '#808000' }, seconds: { light: '#00ffff', dark: '#008080' } },
-            pastel: { month: { light: '#f4a8e1', dark: '#a1428a' }, day: { light: '#a8f4b6', dark: '#42a155' }, hours: { light: '#f4a8a8', dark: '#a14242' }, minutes: { light: '#f4f4a8', dark: '#a1a142' }, seconds: { light: '#a8e1f4', dark: '#428aa1' } },
-            colorblind: { month: { light: '#f7931a', dark: '#a45c05' }, day: { light: '#0072b2', dark: '#003c5c' }, hours: { light: '#d55e00', dark: '#7a3600' }, minutes: { light: '#f0e442', dark: '#8a8326' }, seconds: { light: '#cccccc', dark: '#666666' } }
+            default: { week: { light: '#82aaff', dark: '#2854a8' }, month: { light: '#D05CE3', dark: '#4A0055' }, day: { light: '#81C784', dark: '#003D00' }, hours: { light: '#FF9E80', dark: '#8C1C00' }, minutes: { light: '#FFF176', dark: '#B45F06' }, seconds: { light: '#81D4FA', dark: '#002E5C' } },
+            neon: { week: { light: '#82aaff', dark: '#2854a8' }, month: { light: '#ff00ff', dark: '#800080' }, day: { light: '#00ff00', dark: '#008000' }, hours: { light: '#ff0000', dark: '#800000' }, minutes: { light: '#ffff00', dark: '#808000' }, seconds: { light: '#00ffff', dark: '#008080' } },
+            pastel: { week: { light: '#82aaff', dark: '#2854a8' }, month: { light: '#f4a8e1', dark: '#a1428a' }, day: { light: '#a8f4b6', dark: '#42a155' }, hours: { light: '#f4a8a8', dark: '#a14242' }, minutes: { light: '#f4f4a8', dark: '#a1a142' }, seconds: { light: '#a8e1f4', dark: '#428aa1' } },
+            colorblind: { week: { light: '#82aaff', dark: '#2854a8' }, month: { light: '#f7931a', dark: '#a45c05' }, day: { light: '#0072b2', dark: '#003c5c' }, hours: { light: '#d55e00', dark: '#7a3600' }, minutes: { light: '#f0e442', dark: '#8a8326' }, seconds: { light: '#cccccc', dark: '#666666' } }
         };
 
         function update(timestamp) {
@@ -1266,6 +1346,7 @@ document.addEventListener('DOMContentLoaded', function() {
             const savedSettings = localStorage.getItem('polarClockSettings');
             const defaultSettings = {
                 is24HourFormat: false, labelDisplayMode: 'standard', showDateLines: true, showTimeLines: true, useGradient: true, colorPreset: 'default',
+                showWeekBar: false,
                 volume: 1.0, timerSound: 'bell01.mp3', alarmSound: 'bell01.mp3', stopwatchSound: 'Tick_Tock.wav', pomodoroGlowEnabled: true, pomodoroPulseEnabled: true
             };
             Object.assign(settings, defaultSettings, JSON.parse(savedSettings || '{}'));
@@ -1282,6 +1363,7 @@ document.addEventListener('DOMContentLoaded', function() {
             document.getElementById('gradientToggle').checked = settings.useGradient;
             document.getElementById('dateLinesToggle').checked = settings.showDateLines;
             document.getElementById('timeLinesToggle').checked = settings.showTimeLines;
+            document.getElementById('weekBarToggle').checked = settings.showWeekBar;
             document.getElementById('volumeControl').value = settings.volume;
             document.getElementById('pomodoroGlowToggle').checked = settings.pomodoroGlowEnabled;
             document.getElementById('pomodoroPulseToggle').checked = settings.pomodoroPulseEnabled;
@@ -1333,6 +1415,7 @@ document.addEventListener('DOMContentLoaded', function() {
             document.getElementById('gradientToggle').addEventListener('change', (e) => { settings.useGradient = e.target.checked; saveSettings(); });
             document.getElementById('dateLinesToggle').addEventListener('change', (e) => { settings.showDateLines = e.target.checked; saveSettings(); App.Clock.resize(); });
             document.getElementById('timeLinesToggle').addEventListener('change', (e) => { settings.showTimeLines = e.target.checked; saveSettings(); App.Clock.resize(); });
+            document.getElementById('weekBarToggle').addEventListener('change', (e) => { settings.showWeekBar = e.target.checked; saveSettings(); App.Clock.resize(); });
             document.getElementById('volumeControl').addEventListener('input', (e) => { settings.volume = parseFloat(e.target.value); saveSettings(); });
             document.getElementById('pomodoroGlowToggle').addEventListener('change', (e) => { settings.pomodoroGlowEnabled = e.target.checked; saveSettings(); });
             document.getElementById('pomodoroPulseToggle').addEventListener('change', (e) => { settings.pomodoroPulseEnabled = e.target.checked; saveSettings(); });


### PR DESCRIPTION
This commit introduces two new features to the polar clock:

1.  A new, toggleable 'Week of the Year' data arc.
    *   Adds a 'showWeekBar' setting to control visibility.
    *   Includes a new toggle in the settings panel.
    *   The clock's drawing and resizing logic is updated to handle the new, optional arc.
    *   A new color has been added to all palettes for the week arc.

2.  Re-implements decorative separator lines for all time and date arcs.
    *   A reusable `drawSeparators` function is created to draw radial lines with a 'cutout' effect by using the background color.
    *   The lines are drawn conditionally based on the 'Date Lines' and 'Time Lines' settings.
    *   The separator at the 6 o'clock position is skipped as requested.
    *   The number of separators is dynamic (e.g., days in month, 52 for weeks).