### PR TITLE
Fix: Correct animation loop to make clock live

### DIFF
--- a/index.html
+++ b/index.html
@@ -763,7 +763,6 @@ document.addEventListener('DOMContentLoaded', function() {
         const baseStartAngle = -Math.PI / 2;
         let lastNow = new Date();
         let isFirstFrameDrawn = false;
-        let animationFrameId = null;
 
         const drawArc = (x, y, radius, startAngle, endAngle, colorLight, colorDark, lineWidth) => {
             if (startAngle >= endAngle - 0.01 || radius <= 0) return;
@@ -980,14 +979,13 @@ document.addEventListener('DOMContentLoaded', function() {
             });
         };
 
-        const animate = () => {
+        const draw = () => {
             ctx.clearRect(0, 0, canvas.width, canvas.height);
             if (globalState.mode === 'stopwatch') {
                 drawStopwatch();
             } else {
                 drawClock();
             }
-            animationFrameId = requestAnimationFrame(animate);
         };
 
         App.Clock = {
@@ -995,20 +993,8 @@ document.addEventListener('DOMContentLoaded', function() {
                 settings = initialSettings;
                 globalState = initialState;
                 window.addEventListener('resize', () => this.resize());
-                this.resume();
             },
-            pause: function() {
-                if (animationFrameId) {
-                    cancelAnimationFrame(animationFrameId);
-                    animationFrameId = null;
-                }
-            },
-            resume: function() {
-                if (!animationFrameId) {
-                    lastNow = new Date();
-                    animate();
-                }
-            },
+            draw: draw,
             resize: function() {
                 if (!canvas) return;
                 canvas.width = canvas.offsetWidth;
@@ -1056,7 +1042,6 @@ document.addEventListener('DOMContentLoaded', function() {
             update: function(newSettings, newState) {
                 settings = newSettings;
                 globalState = newState;
-                this.resume();
             }
         };
     }(App));
@@ -1318,6 +1303,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
             checkAdvancedAlarms(now);
             App.Clock.update(settings, state);
+            App.Clock.draw();
             requestAnimationFrame(update);
         }
         let lastFrameTime;


### PR DESCRIPTION
Refactored the animation logic to use a single, authoritative `requestAnimationFrame` loop within the main `update(timestamp)` function.

Removed a redundant and conflicting animation loop from the `Clock` module. The `Clock` module now exposes a `draw()` method that is called on each frame by the main `update` loop.

This ensures the clock correctly displays the current time on startup and animates in real-time as intended.