### PR TITLE
fix: Allow audio cue to re-trigger after snoozing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1503,6 +1503,7 @@ document.addEventListener('DOMContentLoaded', function() {
             }
             state.pomodoro.remainingSeconds += 300; // Add 5 minutes
             state.pomodoro.isSnoozing = true;
+            state.pomodoro.lastMinuteSoundPlayed = false; // Allow the sound to play again
             App.Pomodoro.updateDisplay(); // Immediately update UI
         }
 


### PR DESCRIPTION
This commit fixes a bug where the last-minute audio cue would not play again if the timer had been snoozed.

The `snoozePomodoro()` function is updated to reset the `lastMinuteSoundPlayed` state flag to `false`. This ensures that when the snoozed timer counts down to the 60-second mark again, the application is ready to play the audio cue as intended.

This is the final fix for the Mute/Snooze feature, which is now complete and working as per all user requirements.