### PR TITLE
feat: Pause and resume audio with Pomodoro timer

### DIFF
--- a/index.html
+++ b/index.html
@@ -1225,12 +1225,20 @@ document.addEventListener('DOMContentLoaded', function() {
             start: function() {
                 if (this.state.pomodoro.isRunning) return;
                 this.state.pomodoro.isRunning = true;
+
+                if (this.state.pomodoro.currentAudio && this.state.pomodoro.currentAudio.paused) {
+                    this.state.pomodoro.currentAudio.play();
+                }
+
                 if (this.state.pomodoro.remainingSeconds <= 0) {
                     this.startNextPhase();
                 }
             },
             pause: function() {
                 this.state.pomodoro.isRunning = false;
+                if (this.state.pomodoro.currentAudio) {
+                    this.state.pomodoro.currentAudio.pause();
+                }
             },
             reset: function() {
                 this.state.pomodoro.isRunning = false;


### PR DESCRIPTION
This commit enhances the pause/resume functionality for the Pomodoro timer.

When the 'Pause' button is clicked during the last-minute audio cue, the audio will now pause along with the timer. When the timer is resumed, the audio will resume playing from where it left off.

This change provides a more intuitive user experience and addresses the final piece of feedback on the Mute/Snooze feature set.