### PR TITLE
fix: Correct Pomodoro countdown arc drawing direction

### DIFF
--- a/index.html
+++ b/index.html
@@ -993,10 +993,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
             const pomodoro = globalState.pomodoro;
             const progress = pomodoro.remainingSeconds / pomodoro.totalSeconds;
-            const endAngle = baseStartAngle + (1 - progress) * (Math.PI * 2);
+            const startAngle = baseStartAngle + (1 - progress) * (Math.PI * 2);
 
             // Use a distinct color for the pomodoro timer arc
-            drawArc(dimensions.centerX, dimensions.centerY, dimensions.secondsRadius, baseStartAngle, endAngle, '#ff6347', '#ff4500', 45);
+            drawArc(dimensions.centerX, dimensions.centerY, dimensions.secondsRadius, startAngle, baseStartAngle + Math.PI * 2, '#ff6347', '#ff4500', 45);
         };
 
         const animate = () => {


### PR DESCRIPTION
This commit fixes a visual bug where the Pomodoro countdown arc on the main clock display was filling up instead of emptying.

The logic in the `drawPomodoroClock` function has been corrected to calculate the arc's start and end angles properly, ensuring the arc shrinks as the timer counts down. This aligns the visualization with the expected behavior of a countdown timer.