### PR TITLE
feat: Overhaul separator controls with ruler mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -805,7 +805,7 @@ document.addEventListener('DOMContentLoaded', function() {
             const outerRadius = radius + (arcLineWidth / 2);
             const sixOClockAngle = baseStartAngle + Math.PI;
 
-            ctx.strokeStyle = 'rgba(255, 255, 255, 0.25)'; // Use a semi-transparent white for visibility
+            ctx.strokeStyle = '#121212'; // Background color for "cutout" effect
             ctx.lineWidth = 2; // Separator line width
 
             for (let i = 0; i < count; i++) {
@@ -835,7 +835,7 @@ document.addEventListener('DOMContentLoaded', function() {
             const baseOuterRadius = radius + (arcLineWidth / 2);
             const sixOClockAngle = baseStartAngle + Math.PI;
 
-            ctx.strokeStyle = 'rgba(255, 255, 255, 0.25)'; // Use a semi-transparent white for visibility
+            ctx.strokeStyle = '#121212'; // Background color for "cutout" effect
 
             for (let i = 0; i < count; i++) {
                 const angle = baseStartAngle + (i / count) * Math.PI * 2;


### PR DESCRIPTION
Replaces the "Date Lines" and "Time Lines" toggles with new "Intervals" (Show/Hide) and "Mode" (Standard/Ruler) button groups.

The "Ruler" mode adds detailed tick marks for the minute and second arcs, while other arcs retain standard separators. The visibility of all separators is now controlled by the "Intervals" buttons. The separators are drawn using the background color to create a "cutout" effect.

All clock arcs (Month, Day, Hour, Minute, Second) are now permanently visible, simplifying the rendering logic. The state of the new controls is persisted in localStorage.

Also removes the defunct "Show Weeks Bar" toggle.