### PR TITLE
feat: Overhaul separator controls with ruler mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -808,8 +808,12 @@ document.addEventListener('DOMContentLoaded', function() {
             ctx.strokeStyle = '#121212'; // Background color for "cutout" effect
             ctx.lineWidth = 2; // Separator line width
 
-            for (let i = 0; i < count; i++) {
-                const angle = baseStartAngle + (i / count) * Math.PI * 2;
+            const divisions = (count === 60) ? 12 : count;
+            const step = (count === 60) ? 5 : 1;
+
+            for (let i = 0; i < divisions; i++) {
+                const index = i * step;
+                const angle = baseStartAngle + (index / count) * Math.PI * 2;
 
                 // Skip the 6 o'clock position with a small tolerance
                 if (Math.abs(angle - sixOClockAngle) < 0.01) {


### PR DESCRIPTION
Replaces the "Date Lines" and "Time Lines" toggles with new "Intervals" (Show/Hide) and "Mode" (Standard/Ruler) button groups.

The "Standard" mode for minute and second arcs is updated to only show 12 separators at the 5-unit intervals.

The "Ruler" mode adds detailed tick marks for the minute and second arcs where major ticks are full-width and minor ticks are half-width.

All separators are drawn using the background color to create a "cutout" effect. The visibility of all separators is controlled by the "Intervals" buttons. The state of the new controls is persisted in localStorage.

Also removes the defunct "Show Weeks Bar" toggle.