### PR TITLE
feat: Implement Pomodoro timer display on canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -980,9 +980,65 @@ document.addEventListener('DOMContentLoaded', function() {
             });
         };
 
+        const drawPomodoro = () => {
+            if (!settings.currentColors || !globalState.pomodoro) {
+                return;
+            }
+
+            const now = new Date();
+            const hours = now.getHours(), minutes = now.getMinutes(), seconds = now.getSeconds();
+
+            // Draw time arcs
+            const hoursEndAngle = baseStartAngle + (((hours % 12) + minutes / 60) / 12) * Math.PI * 2;
+            const minutesEndAngle = baseStartAngle + ((minutes + seconds / 60) / 60) * Math.PI * 2;
+            const secondsEndAngle = baseStartAngle + ((seconds + now.getMilliseconds() / 1000) / 60) * Math.PI * 2;
+
+            const timeArcs = [];
+            if (settings.showTimeLines) {
+                timeArcs.push({ key: 'hours', radius: dimensions.hoursRadius, colors: settings.currentColors.hours, lineWidth: 45, endAngle: hoursEndAngle });
+            }
+            timeArcs.push({ key: 'minutes', radius: dimensions.minutesRadius, colors: settings.currentColors.minutes, lineWidth: 30, endAngle: minutesEndAngle });
+            timeArcs.push({ key: 'seconds', radius: dimensions.secondsRadius, colors: settings.currentColors.seconds, lineWidth: 30, endAngle: secondsEndAngle });
+
+            timeArcs.forEach(arc => {
+                if (arc.radius > 0 && settings.currentColors) {
+                    drawArc(dimensions.centerX, dimensions.centerY, arc.radius, baseStartAngle, arc.endAngle, arc.colors.light, arc.colors.dark, arc.lineWidth);
+                    arc.text = getLabelText(arc.key, now);
+                    drawLabel(arc);
+                }
+            });
+
+            // Draw pomodoro arc
+            if (globalState.pomodoro.isRunning && dimensions.timerRadius > 0) {
+                const { phase, remainingSeconds } = globalState.pomodoro;
+                const workDuration = (parseInt(document.getElementById('pomodoroWorkDuration').value) || 25) * 60;
+                const shortBreakDuration = (parseInt(document.getElementById('pomodoroShortBreakDuration').value) || 5) * 60;
+                const longBreakDuration = (parseInt(document.getElementById('pomodoroLongBreakDuration').value) || 15) * 60;
+
+                let totalDuration;
+                if (phase === 'work') totalDuration = workDuration;
+                else if (phase === 'shortBreak') totalDuration = shortBreakDuration;
+                else totalDuration = longBreakDuration;
+
+                if (totalDuration > 0) {
+                    const progress = Math.max(0, remainingSeconds) / totalDuration;
+                    const pomodoroStartAngle = baseStartAngle + (1 - progress) * Math.PI * 2;
+                    const color = (phase === 'work') ? '#82aaff' : '#81C784';
+                    drawArc(dimensions.centerX, dimensions.centerY, dimensions.timerRadius, pomodoroStartAngle, baseStartAngle + Math.PI * 2, color, color, dimensions.timerLineWidth || 30);
+                }
+            }
+
+             // --- Draw Separators for time arcs ---
+            if (settings.showTimeLines) {
+                drawSeparators(dimensions.hoursRadius, 12, dimensions.hoursLineWidth);
+            }
+        };
+
         const animate = () => {
             ctx.clearRect(0, 0, canvas.width, canvas.height);
-            if (globalState.mode === 'stopwatch') {
+            if (globalState.mode === 'pomodoro') {
+                drawPomodoro();
+            } else if (globalState.mode === 'stopwatch') {
                 drawStopwatch();
             } else {
                 drawClock();
@@ -1018,12 +1074,19 @@ document.addEventListener('DOMContentLoaded', function() {
 
                 const baseRadius = Math.min(dimensions.centerX, dimensions.centerY) * 0.9;
                 const monthLineWidth = 20, dayLineWidth = 30, hourLineWidth = 45, minuteLineWidth = 30, secondLineWidth = 30, timerLineWidth = 30, alarmLineWidth = 20, weekLineWidth = 15, gap = 15;
+                const isPomodoro = globalState.mode === 'pomodoro';
 
                 let totalWidth = secondLineWidth / 2 + minuteLineWidth + gap;
                 if (settings.showTimeLines) totalWidth += hourLineWidth + gap;
-                if (settings.showDateLines) totalWidth += dayLineWidth + gap + monthLineWidth + gap;
-                if (settings.showWeekBar) totalWidth += weekLineWidth + gap;
-                if (globalState.timer && globalState.timer.totalSeconds > 0) totalWidth += timerLineWidth + gap;
+
+                if (isPomodoro) {
+                    totalWidth += timerLineWidth + gap;
+                } else {
+                    if (settings.showDateLines) totalWidth += dayLineWidth + gap + monthLineWidth + gap;
+                    if (settings.showWeekBar) totalWidth += weekLineWidth + gap;
+                    if (globalState.timer && globalState.timer.totalSeconds > 0) totalWidth += timerLineWidth + gap;
+                }
+
                 if (globalState.trackedAlarm && globalState.trackedAlarm.nextAlarmTime) totalWidth += alarmLineWidth + gap;
 
                 const scale = baseRadius / totalWidth;
@@ -1041,17 +1104,33 @@ document.addEventListener('DOMContentLoaded', function() {
                 dimensions.hoursRadius = settings.showTimeLines ? currentRadius - (dimensions.hoursLineWidth / 2) : 0;
                 if (settings.showTimeLines) currentRadius -= (dimensions.hoursLineWidth + gap * scale);
 
-                dimensions.dayLineWidth = settings.showDateLines ? dayLineWidth * scale : 0;
-                dimensions.dayRadius = settings.showDateLines ? currentRadius - (dimensions.dayLineWidth / 2) : 0;
-                if (settings.showDateLines) currentRadius -= (dimensions.dayLineWidth + gap * scale);
+                // Reset all conditional radii
+                dimensions.dayRadius = dimensions.monthRadius = dimensions.weekRadius = dimensions.timerRadius = 0;
+                dimensions.dayLineWidth = dimensions.monthLineWidth = dimensions.weekLineWidth = dimensions.timerLineWidth = 0;
 
-                dimensions.monthLineWidth = settings.showDateLines ? monthLineWidth * scale : 0;
-                dimensions.monthRadius = settings.showDateLines ? currentRadius - (dimensions.monthLineWidth / 2) : 0;
-                if (settings.showDateLines) currentRadius -= (dimensions.monthLineWidth + gap * scale);
+                if (isPomodoro) {
+                    dimensions.timerLineWidth = timerLineWidth * scale;
+                    dimensions.timerRadius = currentRadius - (dimensions.timerLineWidth / 2);
+                    currentRadius -= (dimensions.timerLineWidth + gap * scale);
+                } else {
+                    dimensions.dayLineWidth = settings.showDateLines ? dayLineWidth * scale : 0;
+                    dimensions.dayRadius = settings.showDateLines ? currentRadius - (dimensions.dayLineWidth / 2) : 0;
+                    if (settings.showDateLines) currentRadius -= (dimensions.dayLineWidth + gap * scale);
 
-                dimensions.weekLineWidth = settings.showWeekBar ? weekLineWidth * scale : 0;
-                dimensions.weekRadius = settings.showWeekBar ? currentRadius - (dimensions.weekLineWidth / 2) : 0;
-                if (settings.showWeekBar) currentRadius -= (dimensions.weekLineWidth + gap * scale);
+                    dimensions.monthLineWidth = settings.showDateLines ? monthLineWidth * scale : 0;
+                    dimensions.monthRadius = settings.showDateLines ? currentRadius - (dimensions.monthLineWidth / 2) : 0;
+                    if (settings.showDateLines) currentRadius -= (dimensions.monthLineWidth + gap * scale);
+
+                    dimensions.weekLineWidth = settings.showWeekBar ? weekLineWidth * scale : 0;
+                    dimensions.weekRadius = settings.showWeekBar ? currentRadius - (dimensions.weekLineWidth / 2) : 0;
+                    if (settings.showWeekBar) currentRadius -= (dimensions.weekLineWidth + gap * scale);
+
+                    if (globalState.timer && globalState.timer.totalSeconds > 0) {
+                        dimensions.timerLineWidth = timerLineWidth * scale;
+                        dimensions.timerRadius = currentRadius - (dimensions.timerLineWidth / 2);
+                        currentRadius -= (dimensions.timerLineWidth + gap * scale);
+                    }
+                }
             },
             update: function(newSettings, newState) {
                 settings = newSettings;


### PR DESCRIPTION
This commit fixes a visual bug where the Pomodoro timer mode did not show its dedicated countdown display on the main canvas.

The changes include:
- A new `drawPomodoro` function has been created to render the Pomodoro-specific view, as originally requested for better modularity.
- The main `animate` loop is updated to call `drawPomodoro` when the application is in pomodoro mode.
- In Pomodoro mode, the canvas now displays the standard Hours, Minutes, and Seconds arcs, with a new innermost arc representing the Pomodoro timer's progress. The date-related arcs (Month, Day, Week) are hidden.
- The Pomodoro arc's color changes based on the current phase (work/break).
- The `resize` function has been updated to correctly calculate the canvas layout for all modes, ensuring the display is responsive.
- Obsolete 'Glow' and 'Pulse' effects have been ignored as requested.