### PR TITLE
Feat: Apply ruler mode to Pomodoro timer

### DIFF
--- a/js/clock.js
+++ b/js/clock.js
@@ -350,11 +350,21 @@ const Clock = (function() {
 
         // Draw separators if enabled
         if (settings.showSeparators) {
-             if (totalDuration >= 3600) {
+            const isRulerMode = settings.separatorMode === 'ruler';
+
+            // Hour separators are always standard
+            if (totalDuration >= 3600) {
                 drawSeparators(dimensions.hoursRadius, 12, dimensions.hoursLineWidth);
             }
-            drawSeparators(dimensions.minutesRadius, 60, dimensions.minutesLineWidth);
-            drawSeparators(dimensions.secondsRadius, 60, dimensions.secondsLineWidth);
+
+            // Apply ruler mode only to minutes and seconds
+            if (isRulerMode) {
+                drawRulerSeparators(dimensions.minutesRadius, 60, dimensions.minutesLineWidth);
+                drawRulerSeparators(dimensions.secondsRadius, 60, dimensions.secondsLineWidth);
+            } else {
+                drawSeparators(dimensions.minutesRadius, 60, dimensions.minutesLineWidth);
+                drawSeparators(dimensions.secondsRadius, 60, dimensions.secondsLineWidth);
+            }
         }
     };
 


### PR DESCRIPTION
This commit adds the 'ruler' separator style to the Pomodoro timer view.

The `drawPomodoro` function in `js/clock.js` has been updated to check the `settings.separatorMode` and call the appropriate separator drawing function (`drawRulerSeparators` or `drawSeparators`) for the minutes and seconds arcs. This aligns its behavior with the main clock view.