### PR TITLE
feat: Implement dynamic Pomodoro controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -442,10 +442,13 @@
                     </div>
                     <div id="pomodoroTimerDisplay" class="text-6xl font-mono">25:00</div>
                 </div>
-                <div class="control-buttons">
-                    <button id="startPomodoro">Start</button>
-                    <button id="pausePomodoro">Pause</button>
-                    <button id="resetPomodoro">Reset</button>
+                <div class="control-buttons" id="pomodoro-main-controls">
+                    <button id="togglePomodoroBtn">Start</button>
+                    <button id="resetPomodoro" style="display: none;">Reset</button>
+                </div>
+                <div class="control-buttons" id="pomodoroAlarmControls" style="display: none;">
+                    <button id="mutePomodoroBtn">Mute</button>
+                    <button id="snoozePomodoroBtn">Snooze</button>
                 </div>
                 <div class="settings-section w-full max-w-xs">
                     <h3 class="text-sm uppercase text-gray-400 mt-4">Settings</h3>


### PR DESCRIPTION
Refactors the Pomodoro timer's control panel to be more intuitive and interactive.

- Combines the 'Start' and 'Pause' buttons into a single 'Start/Pause' toggle button.
- The 'Reset' button is now hidden until the timer is started for the first time.
- When a timer cycle finishes, new 'Mute' and 'Snooze' controls are displayed.
- Snoozing adds 5 minutes to the timer and transforms the 'Snooze' button into an 'End Cycle' button.
- The 'Mute' button toggles the alarm sound and provides visual feedback.