### PR TITLE
feat: Final UX improvements for Pomodoro timer

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <!-- DEPENDENCIES: Tailwind CSS for styling and Phosphor Icons for UI icons -->
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://unpkg.com/@phosphor-icons/web"></script>
+    <link href="https://fonts.cdnfonts.com/css/oswald-4" rel="stylesheet">
     <style>
     /* General page styling */
     body {
@@ -17,7 +18,7 @@
         margin: 0;
         background-color: #121212;
         color: #ffffff;
-        font-family: 'Bahnschrift', sans-serif;
+        font-family: 'Oswald', sans-serif;
         overflow: hidden;
     }
 
@@ -335,7 +336,6 @@
     }
 
     .pomodoro-display {
-        font-family: 'Courier New', Courier, monospace;
         font-size: 2.5rem;
     }
 
@@ -582,6 +582,10 @@
                 <div class="flex justify-between w-full items-center">
                     <label for="pomodoroLongBreakDuration">Long Break Duration</label>
                     <input type="text" id="pomodoroLongBreakDuration" class="time-input-small" value="15">
+                </div>
+                <div class="control-buttons mt-4">
+                    <button id="cancelPomodoroSettings">Cancel</button>
+                    <button id="submitPomodoroSettings">Submit</button>
                 </div>
             </div>
         </div>

--- a/js/clock.js
+++ b/js/clock.js
@@ -274,9 +274,9 @@ const Clock = (function() {
         const { phase, remainingSeconds } = globalState.pomodoro;
 
         // Determine total duration for the current phase to calculate progress
-        const workDuration = (parseInt(document.getElementById('pomodoroWorkDuration').value) || 25) * 60;
-        const shortBreakDuration = (parseInt(document.getElementById('pomodoroShortBreakDuration').value) || 5) * 60;
-        const longBreakDuration = (parseInt(document.getElementById('pomodoroLongBreakDuration').value) || 15) * 60;
+        const workDuration = (settings.pomodoroWorkDuration || 25) * 60;
+        const shortBreakDuration = (settings.pomodoroShortBreakDuration || 5) * 60;
+        const longBreakDuration = (settings.pomodoroLongBreakDuration || 15) * 60;
 
         let totalDuration;
         if (phase === 'work') {
@@ -299,7 +299,7 @@ const Clock = (function() {
 
         // Only show hours arc if total duration is an hour or more
         if (totalDuration >= 3600) {
-            const hoursProgress = (hours + (minutes / 60) + (seconds / 3600)) / 12; // Progress for a 12h clock
+            const hoursProgress = ((hours % 12) + (minutes / 60) + (seconds / 3600)) / 12; // Progress for a 12h clock
             const hoursEndAngle = baseStartAngle + hoursProgress * Math.PI * 2;
             arcs.push({
                 key: 'hours',

--- a/js/main.js
+++ b/js/main.js
@@ -26,7 +26,6 @@ document.addEventListener('DOMContentLoaded', function() {
             }
             return parseFloat(timeString) || 0;
         }
-
         const clockContainer = document.querySelector('.canvas-container');
         const digitalTime = document.getElementById('digitalTime');
         const digitalDate = document.getElementById('digitalDate');
@@ -90,10 +89,6 @@ document.addEventListener('DOMContentLoaded', function() {
             applySettingsToUI();
         }
         function applySettingsToUI() {
-            document.getElementById('pomodoroWorkDuration').value = formatMinutesToHHMMSS(settings.pomodoroWorkDuration);
-            document.getElementById('pomodoroShortBreakDuration').value = formatMinutesToHHMMSS(settings.pomodoroShortBreakDuration);
-            document.getElementById('pomodoroLongBreakDuration').value = formatMinutesToHHMMSS(settings.pomodoroLongBreakDuration);
-
             document.getElementById('format12').classList.toggle('active', !settings.is24HourFormat);
             document.getElementById('format24').classList.toggle('active', settings.is24HourFormat);
             ['modeStandard', 'modePercentage', 'modeRemainder'].forEach(id => document.getElementById(id).classList.remove('active'));
@@ -167,40 +162,72 @@ document.addEventListener('DOMContentLoaded', function() {
             const pomodoroSettingsModal = document.getElementById('pomodoroSettingsModal');
             const pomodoroSettingsBtn = document.getElementById('pomodoroSettingsBtn');
             const closePomodoroSettingsBtn = document.getElementById('closePomodoroSettingsBtn');
+            const cancelPomodoroSettingsBtn = document.getElementById('cancelPomodoroSettings');
+            const submitPomodoroSettingsBtn = document.getElementById('submitPomodoroSettings');
             const workDurationInput = document.getElementById('pomodoroWorkDuration');
             const shortBreakDurationInput = document.getElementById('pomodoroShortBreakDuration');
             const longBreakDurationInput = document.getElementById('pomodoroLongBreakDuration');
 
-            pomodoroSettingsBtn.addEventListener('click', () => {
+            let tempSettings = {};
+
+            function openModal() {
+                tempSettings = {
+                    pomodoroWorkDuration: settings.pomodoroWorkDuration,
+                    pomodoroShortBreakDuration: settings.pomodoroShortBreakDuration,
+                    pomodoroLongBreakDuration: settings.pomodoroLongBreakDuration,
+                };
+                workDurationInput.value = formatMinutesToHHMMSS(tempSettings.pomodoroWorkDuration);
+                shortBreakDurationInput.value = formatMinutesToHHMMSS(tempSettings.pomodoroShortBreakDuration);
+                longBreakDurationInput.value = formatMinutesToHHMMSS(tempSettings.pomodoroLongBreakDuration);
                 pomodoroSettingsModal.classList.remove('hidden');
-            });
+            }
 
-            closePomodoroSettingsBtn.addEventListener('click', () => {
+            function closeModal() {
+                workDurationInput.value = formatMinutesToHHMMSS(settings.pomodoroWorkDuration);
+                shortBreakDurationInput.value = formatMinutesToHHMMSS(settings.pomodoroShortBreakDuration);
+                longBreakDurationInput.value = formatMinutesToHHMMSS(settings.pomodoroLongBreakDuration);
                 pomodoroSettingsModal.classList.add('hidden');
-                document.getElementById('resetPomodoro').click();
-            });
+            }
 
-            function handleFocus(input, settingName) {
+            function submitSettings() {
+                settings.pomodoroWorkDuration = tempSettings.pomodoroWorkDuration;
+                settings.pomodoroShortBreakDuration = tempSettings.pomodoroShortBreakDuration;
+                settings.pomodoroLongBreakDuration = tempSettings.pomodoroLongBreakDuration;
+                saveSettings();
+                applySettingsToUI();
+                closeModal();
+                document.getElementById('resetPomodoro').click();
+            }
+
+            function handleFocus(input) {
                 input.value = parseHHMMSSToMinutes(input.value);
             }
 
             function handleChange(input, settingName) {
                 let value = parseFloat(input.value);
                 if (isNaN(value) || value < 0) {
-                    value = settings[settingName]; // revert to old value
+                    value = tempSettings[settingName]; // revert to old value
                 }
-                settings[settingName] = value;
-                saveSettings();
+                if (value > 1440) {
+                    value = 1440;
+                }
+                tempSettings[settingName] = value;
                 input.value = formatMinutesToHHMMSS(value);
             }
 
-            workDurationInput.addEventListener('focus', () => handleFocus(workDurationInput, 'pomodoroWorkDuration'));
+            pomodoroSettingsBtn.addEventListener('click', openModal);
+            closePomodoroSettingsBtn.addEventListener('click', closeModal);
+            cancelPomodoroSettingsBtn.addEventListener('click', closeModal);
+            submitPomodoroSettingsBtn.addEventListener('click', submitSettings);
+
+
+            workDurationInput.addEventListener('focus', () => handleFocus(workDurationInput));
             workDurationInput.addEventListener('change', () => handleChange(workDurationInput, 'pomodoroWorkDuration'));
 
-            shortBreakDurationInput.addEventListener('focus', () => handleFocus(shortBreakDurationInput, 'pomodoroShortBreakDuration'));
+            shortBreakDurationInput.addEventListener('focus', () => handleFocus(shortBreakDurationInput));
             shortBreakDurationInput.addEventListener('change', () => handleChange(shortBreakDurationInput, 'pomodoroShortBreakDuration'));
 
-            longBreakDurationInput.addEventListener('focus', () => handleFocus(longBreakDurationInput, 'pomodoroLongBreakDuration'));
+            longBreakDurationInput.addEventListener('focus', () => handleFocus(longBreakDurationInput));
             longBreakDurationInput.addEventListener('change', () => handleChange(longBreakDurationInput, 'pomodoroLongBreakDuration'));
         }
 


### PR DESCRIPTION
This commit introduces several UX improvements to the Pomodoro timer based on user feedback.

The changes include:
- The font for the entire application has been changed to "Oswald".
- The "Custom Cycles" modal now has "Submit" and "Cancel" buttons for explicit control over saving changes.
- The hour arc has been re-enabled in the clock visualization for longer timer sessions.
- The maximum duration for any timer phase is now capped at 24 hours (1440 minutes).