### PR TITLE
fix: Re-implement continuous mode and add snooze color change

### DIFF
--- a/index.html
+++ b/index.html
@@ -464,6 +464,13 @@
                         <label for="pomodoroLongBreakDuration">Long Break (min)</label>
                         <input type="number" id="pomodoroLongBreakDuration" class="time-input-small" value="15" min="1">
                     </div>
+                    <div class="flex justify-between w-full items-center mt-2">
+                        <label for="pomodoroContinuousToggle">Continuous Mode</label>
+                        <label class="switch">
+                            <input type="checkbox" id="pomodoroContinuousToggle">
+                            <span class="slider"></span>
+                        </label>
+                    </div>
                 </div>
             </div>
             <!-- Stopwatch Panel -->

--- a/js/tools.js
+++ b/js/tools.js
@@ -26,6 +26,7 @@ const Tools = (function() {
     const pomodoroAlarmControls = document.getElementById('pomodoroAlarmControls');
     const mutePomodoroBtn = document.getElementById('mutePomodoroBtn');
     const snoozePomodoroBtn = document.getElementById('snoozePomodoroBtn');
+    const pomodoroContinuousToggle = document.getElementById('pomodoroContinuousToggle');
 
     // --- Module State ---
     let settings = {};
@@ -39,7 +40,8 @@ const Tools = (function() {
             alarmPlaying: false,
             isMuted: false,
             isSnoozed: false,
-            hasStarted: false
+            hasStarted: false,
+            continuous: false
         },
         stopwatch: { startTime: 0, elapsedTime: 0, isRunning: false, laps: [] }
     };
@@ -185,6 +187,7 @@ const Tools = (function() {
         state.pomodoro.isMuted = false;
         state.pomodoro.isSnoozed = false;
         state.pomodoro.hasStarted = false;
+        timerDisplay.style.color = ''; // Reset color
         updatePomodoroDisplay();
         updatePomodoroUI();
         document.dispatchEvent(new CustomEvent('pomodoro-reset'));
@@ -207,6 +210,7 @@ const Tools = (function() {
         state.pomodoro.remainingSeconds += 5 * 60; // Add 5 minutes
         state.pomodoro.alarmPlaying = false;
         state.pomodoro.isMuted = false; // Ensure next alarm is not muted
+        timerDisplay.style.color = '#FFDB58'; // Mustard yellow for snooze
         updatePomodoroDisplay();
         updatePomodoroUI();
     }
@@ -214,6 +218,7 @@ const Tools = (function() {
     function endCycle() {
         state.pomodoro.isSnoozed = false;
         state.pomodoro.alarmPlaying = false;
+        timerDisplay.style.color = ''; // Reset color
         startNextPomodoroPhase(true);
         updatePomodoroUI();
     }
@@ -326,6 +331,9 @@ const Tools = (function() {
         resetPomodoroBtn.addEventListener('click', resetPomodoro);
         mutePomodoroBtn.addEventListener('click', muteAlarm);
         snoozePomodoroBtn.addEventListener('click', snoozeAlarm);
+        pomodoroContinuousToggle.addEventListener('change', (e) => {
+            state.pomodoro.continuous = e.target.checked;
+        });
     }
 
 
@@ -347,13 +355,17 @@ const Tools = (function() {
             if (state.pomodoro.isRunning && !state.pomodoro.alarmPlaying) {
                 state.pomodoro.remainingSeconds -= deltaTime;
                 if (state.pomodoro.remainingSeconds <= 0) {
-                    state.pomodoro.remainingSeconds = 0;
                     state.pomodoro.isRunning = false;
-                    state.pomodoro.alarmPlaying = true;
-                    if (!state.pomodoro.isMuted) {
-                        playSound(settings.timerSound || 'bell01.mp3');
+                    if (state.pomodoro.continuous) {
+                        startNextPomodoroPhase(true);
+                    } else {
+                        state.pomodoro.remainingSeconds = 0;
+                        state.pomodoro.alarmPlaying = true;
+                        if (!state.pomodoro.isMuted) {
+                            playSound(settings.timerSound || 'bell01.mp3');
+                        }
+                        updatePomodoroUI();
                     }
-                    updatePomodoroUI();
                 }
             }
             updatePomodoroDisplay(); // Keep display updated regardless of running state


### PR DESCRIPTION
This commit addresses a regression where the continuous mode functionality was removed. It also adds a user-requested visual feedback feature for the snooze function.

- Adds a 'Continuous Mode' toggle to the Pomodoro settings.
- When enabled, the timer automatically proceeds to the next cycle.
- When disabled, the new interactive alarm controls are shown.
- The timer display now turns mustard yellow when the timer is snoozed to provide clear visual feedback.
- The timer color is reset when the snooze ends or the timer is reset.