### PR TITLE
fix: Refactor Pomodoro to use state and add settings modal

### DIFF
--- a/js/clock.js
+++ b/js/clock.js
@@ -273,18 +273,16 @@ const Clock = (function() {
 
         const { phase, remainingSeconds } = globalState.pomodoro;
 
-        // Determine total duration for the current phase to calculate progress
-        const workDuration = (parseInt(document.getElementById('pomodoroWorkDuration').value) || 25) * 60;
-        const shortBreakDuration = (parseInt(document.getElementById('pomodoroShortBreakDuration').value) || 5) * 60;
-        const longBreakDuration = (parseInt(document.getElementById('pomodoroLongBreakDuration').value) || 15) * 60;
+        // Determine total duration for the current phase from the state object
+        const { workDuration, shortBreakDuration, longBreakDuration } = globalState.pomodoro;
 
         let totalDuration;
         if (phase === 'work') {
-            totalDuration = workDuration;
+            totalDuration = workDuration * 60;
         } else if (phase === 'shortBreak') {
-            totalDuration = shortBreakDuration;
+            totalDuration = shortBreakDuration * 60;
         } else { // longBreak
-            totalDuration = longBreakDuration;
+            totalDuration = longBreakDuration * 60;
         }
 
         // Calculate remaining time components


### PR DESCRIPTION
This commit resolves a series of UI and logic issues with the Pomodoro timer, culminating in a full refactor of its settings management and a fix for a critical rendering bug.

- Replaces the static, on-page settings panel with a 'Custom' button that opens a new modal for all timer settings (`pomodoroSettingsModal`).
- The new modal contains inputs for work, short break, and long break durations, as well as the 'Continuous Mode' toggle.
- Refactors the JavaScript in `js/tools.js` to manage Pomodoro settings in a central state object, removing dependencies on static DOM elements.
- Fixes a bug in continuous mode where the next cycle would not start automatically.
- Fixes a critical bug in `js/clock.js` where the `drawPomodoro` function was attempting to read from deleted DOM elements, causing the clock to fail to render. The function now correctly reads duration values from the state object.