### PR TITLE
fix: Resolve Pomodoro crashes and add Next Cycle button

### DIFF
--- a/index.html
+++ b/index.html
@@ -498,6 +498,7 @@
                 </div>
                 <div class="control-buttons" id="pomodoroAlarmControls" style="display: none;">
                     <button id="mutePomodoroBtn">Mute</button>
+                    <button id="nextCyclePomodoroBtn">Next Cycle</button>
                     <button id="snoozePomodoroBtn">Snooze</button>
                 </div>
                 <!-- This settings section is now replaced by the modal -->

--- a/js/tools.js
+++ b/js/tools.js
@@ -25,6 +25,7 @@ const Tools = (function() {
     const pomodoroAlarmControls = document.getElementById('pomodoroAlarmControls');
     const mutePomodoroBtn = document.getElementById('mutePomodoroBtn');
     const snoozePomodoroBtn = document.getElementById('snoozePomodoroBtn');
+    const nextCyclePomodoroBtn = document.getElementById('nextCyclePomodoroBtn');
     const customPomodoroBtn = document.getElementById('customPomodoroBtn');
     const pomodoroSettingsModal = document.getElementById('pomodoroSettingsModal');
     const closePomodoroSettingsBtn = document.getElementById('closePomodoroSettingsBtn');
@@ -258,7 +259,7 @@ const Tools = (function() {
         if (playSoundOnStart && !state.pomodoro.isMuted) {
             playSound(settings.timerSound);
         }
-        updatePomodoroDisplay();
+        updatePomodoroDashboard();
         state.pomodoro.isRunning = true; // Auto-start the next cycle
     }
 
@@ -366,6 +367,7 @@ const Tools = (function() {
         resetPomodoroBtn.addEventListener('click', resetPomodoro);
         mutePomodoroBtn.addEventListener('click', muteAlarm);
         snoozePomodoroBtn.addEventListener('click', snoozeAlarm);
+        nextCyclePomodoroBtn.addEventListener('click', endCycle);
         // This listener is for the modal's toggle.
         continuousToggleModalInput.addEventListener('change', (e) => {
             state.pomodoro.continuous = e.target.checked;


### PR DESCRIPTION
This commit fixes several critical bugs in the Pomodoro timer and adds a new feature based on user feedback.

- Fixes a `ReferenceError` crash caused by calling a deleted function (`updatePomodoroDisplay`). All calls have been updated to the new `updatePomodoroDashboard` function. This resolves the clock drawing issue.
- Corrects the continuous mode logic to ensure the next cycle starts automatically and begins counting down immediately.
- Adds a 'Next Cycle' button to the alarm controls that appear in manual mode, allowing users to advance the timer without snoozing.