### PR TITLE
feat: Add mute and snooze buttons to Pomodoro timer

### DIFF
--- a/index.html
+++ b/index.html
@@ -622,10 +622,12 @@
                     <button id="resetPomodoro" style="display: none;">Reset</button>
                     <button id="customPomodoroBtn">Custom</button>
                 </div>
+                <div class="control-buttons" id="pomodoroActions" style="display: none;">
+                    <button id="pomodoroMuteBtn"><i class="ph ph-speaker-slash"></i></button>
+                    <button id="pomodoroSnoozeBtn"><i class="ph ph-bell-z"></i></button>
+                </div>
                 <div class="control-buttons" id="pomodoroAlarmControls" style="display: none;">
-                    <button id="mutePomodoroBtn">Mute</button>
                     <button id="nextCyclePomodoroBtn">Next Cycle</button>
-                    <button id="snoozePomodoroBtn">Snooze</button>
                 </div>
                 <!-- This settings section is now replaced by the modal -->
             </div>


### PR DESCRIPTION
This commit introduces new user controls for the Pomodoro timer: a mute button and a snooze button. These buttons appear only during the final minute of a work or break cycle.

- Adds a new UI container `pomodoroActions` to the HTML, containing the mute and snooze buttons.
- Defines new state variables in the `pomodoro` object to track the new functionality.
- Implements logic in the main update function to manage the visibility of the action buttons and play a notification sound once per cycle.
- Creates two new functions, `mutePomodoroAudio` and `snoozePomodoro`, to handle the button clicks.
- Attaches event listeners to the new buttons.
- Includes fixes for bugs identified during code review, such as ensuring proper state reset between cycles and preventing UI glitches.