### PR TITLE
feat(timer): Add mute and snooze functionality to timer

### DIFF
--- a/index.html
+++ b/index.html
@@ -353,6 +353,10 @@
         color: #FFDB58 !important; /* Mustard Yellow */
     }
 
+    .time-inputs.snoozed input {
+        color: #F44336 !important; /* Red for snoozing */
+    }
+
     .time-input-small {
         width: 60px;
         background: #2a2a2a;
@@ -577,9 +581,14 @@
                         <label>Seconds</label>
                     </div>
                 </div>
-                <div class="control-buttons">
+                <div class="control-buttons" id="timer-main-controls">
                     <button id="toggleTimerBtn">Start</button>
                     <button id="resetTimer">Reset</button>
+                </div>
+                <div class="control-buttons" id="timerAlarmControls" style="display: none;">
+                    <button id="timerMuteBtn" class="control-btn"><i class="ph ph-speaker-slash"></i></button>
+                    <button id="timerSnoozeBtn" class="control-btn"><i class="ph ph-bell-z"></i></button>
+                    <button id="timerStopBtn" class="control-btn">Stop</button>
                 </div>
                  <div class="setting-toggle">
                     <span>Repeat</span>


### PR DESCRIPTION
This commit adds mute and snooze functionality to the regular timer, mirroring the features of the Pomodoro timer.

Key changes include:
- Extending the timer state to include `alarmPlaying`, `isMutedThisCycle`, and `isSnoozing`.
- Adding new UI controls for mute, snooze, and stop that appear when the timer finishes.
- Refactoring the `timerFinished` function to handle the end-of-cycle state, allowing for user interaction instead of automatic reset (unless in interval mode).
- Implementing `muteTimerAudio`, `snoozeTimer`, and `stopTimerAlarm` functions to manage the new interactions.
- Updating `resetTimer` to clear all new state flags and stop any playing audio.
- Adding visual feedback for the snoozing state by applying a `.snoozed` class to the timer inputs.