### PR TITLE
fix(css): Make UI panel a true overlay and ensure nav buttons are vis…

### DIFF
--- a/index.html
+++ b/index.html
@@ -454,16 +454,14 @@
             top: 0;
             width: 380px;
             z-index: 100;
-            background-color: rgba(26, 26, 26, 0.85);
-            backdrop-filter: blur(10px);
-            -webkit-backdrop-filter: blur(10px);
-            transform: translateX(100%);
-            transition: transform 0.3s ease-in-out;
-            /* The panel is no longer a flex item in this view, so flex-basis is not needed. */
+            /* By default, the container is transparent and positioned as an overlay. */
+            /* The nav buttons inside are still clickable without affecting the clock layout. */
         }
 
         body.panel-open .ui-container {
-            transform: translateX(0);
+            background-color: rgba(26, 26, 26, 0.85);
+            backdrop-filter: blur(10px);
+            -webkit-backdrop-filter: blur(10px);
         }
     }
 


### PR DESCRIPTION
…ible

Refactored the CSS to prevent the UI panel from affecting the main content layout on desktop screens, while ensuring the main navigation buttons remain visible at all times.

- Changed `body` `justify-content` to `center` to ensure the clock container is always centered.
- Made `.ui-container` `position: absolute` within a desktop media query to remove it from the document flow.
- The `.ui-container` is now transparent by default, making the navigation buttons inside it visible and clickable.
- The semi-transparent overlay background is now applied only to `body.panel-open .ui-container`, so it appears only when a content panel is active.

This change fixes the initial layout issue and corrects a regression where the navigation buttons were unintentionally hidden. The clock remains centered, the panel acts as a true overlay, and the UI is fully operable. The mobile layout is unaffected.