### PR TITLE
Style: Adjust vertical position of main navigation toolbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,8 @@
         display: flex;
         flex-direction: column;
         align-items: center;
-        justify-content: center; /* Center nav buttons */
+        justify-content: flex-start; /* Position at the top */
+        padding-top: 2rem; /* Add some space from the top */
         height: 100vh; /* Full height for vertical centering */
         flex-basis: 100px; /* Give it a bit of space */
         flex-shrink: 0;


### PR DESCRIPTION
This commit adjusts the CSS for the #mainView element to move the main navigation buttons higher up on the screen. The vertical alignment is changed from `center` to `flex-start` and a `padding-top` is added.

This change addresses the user's feedback to move the unopened toolbar to the top right of the screen.