### PR TITLE
fix: Prevent clock overflow and repair mobile buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,7 @@
         width: 95vh; /* Make the clock container a square based on viewport height */
         height: 95vh;
         max-width: 100%; /* Ensure it doesn't overflow its parent flex container */
+        max-height: 100%;
     }
 
     canvas {


### PR DESCRIPTION
This commit resolves a follow-up issue where buttons in the UI panels were inoperable on mobile devices.

The root cause was the `.clock-square-wrapper` element overflowing its parent container in the mobile view, invisibly covering the UI panels and intercepting click events.

The fix adds `max-height: 100%` to the `.clock-square-wrapper` CSS rule, ensuring it is always constrained within its parent's bounds. This resolves the element overflow and makes the buttons fully interactive again.