### PR TITLE
feat: Reactivate 'Default' clock option in tools

### DIFF
--- a/index.html
+++ b/index.html
@@ -596,6 +596,7 @@
             <button id="backToMainFromTools" class="back-button">Back</button>
         </div>
         <div class="tab-buttons">
+            <button id="defaultTab" class="tab-button">Default</button>
             <button id="timerTab" class="tab-button">Timer</button>
             <button id="pomodoroTab" class="tab-button">Pomodoro</button>
             <button id="stopwatchTab" class="tab-button">Stopwatch</button>

--- a/js/ui.js
+++ b/js/ui.js
@@ -16,6 +16,7 @@ const UI = (function() {
         backFromAbout: document.getElementById('backToMainFromAbout'),
     };
     const toolTabs = {
+        default: document.getElementById('defaultTab'),
         timer: document.getElementById('timerTab'),
         pomodoro: document.getElementById('pomodoroTab'),
         stopwatch: document.getElementById('stopwatchTab'),
@@ -215,6 +216,7 @@ const UI = (function() {
             navButtons.goToAlarms.addEventListener('click', () => { window.location.href = 'alarms.html'; });
 
             // Unified tool tab event listeners
+            toolTabs.default.addEventListener('click', () => showToolsPanel(null, toolTabs.default));
             toolTabs.timer.addEventListener('click', () => showToolsPanel(toolPanels.timer, toolTabs.timer));
             toolTabs.pomodoro.addEventListener('click', () => showToolsPanel(toolPanels.pomodoro, toolTabs.pomodoro));
             toolTabs.stopwatch.addEventListener('click', () => showToolsPanel(toolPanels.stopwatch, toolTabs.stopwatch));


### PR DESCRIPTION
Re-introduces the 'Default' tab in the tools section, allowing the user to set the main clock as the focus while keeping the tools panel open.

- Added a 'Default' button to the tool tabs in `index.html`.
- Updated `js/ui.js` to handle the new tab:
  - Added the 'Default' tab to the `toolTabs` object.
  - Created an event listener that sets the application mode to 'clock' when the 'Default' tab is clicked.

This restores the previously existing functionality as requested by the user.