### PR TITLE
Add safeguards to suggestion box

### DIFF
--- a/index.html
+++ b/index.html
@@ -745,6 +745,8 @@
                         <input type="text" id="feedbackTitle" name="subject" placeholder="Subject">
                         <textarea id="feedbackMessage" name="message" rows="5" placeholder="Your message..."></textarea>
                         <button type="submit" id="submitFeedbackBtn">Submit</button>
+                        <p class="text-xs text-gray-500 mt-2 text-center">Limited to 3 per day.</p>
+                        <div id="feedbackStatus" class="mt-2 text-center"></div>
                     </form>
                 </div>
             </div>


### PR DESCRIPTION
This commit introduces two safeguards to the suggestion box feature to prevent abuse:
- Empty messages are no longer allowed. The message body must contain at least one character.
- Users are limited to 3 submissions per device per 24-hour period. This is tracked using localStorage.

Additionally, a message "Limited to 3 per day." is now displayed in the feedback form section to inform users of the submission limit.