### PR TITLE
This commit fixes the mute functionality for the Timer tool to make i…

### DIFF
--- a/index.html
+++ b/index.html
@@ -268,7 +268,7 @@
         border-color: #666;
     }
 
-    #pomodoroMuteBtn.active {
+    #pomodoroMuteBtn.active, #timerMuteBtn.active {
         background-color: #4CAF50;
         color: white;
     }


### PR DESCRIPTION
…t a toggle.

Key changes:
- The `isMutedThisCycle` state property was renamed to `isMuted` for clarity and its logic was updated to be a toggle.
- The `muteTimerAudio` function now toggles the `isMuted` state and the `muted` property of the currently playing audio. It also toggles an `.active` class on the mute button for visual feedback.
- A CSS rule was added to `index.html` to style the active mute button.
- The sound playing logic in `update` and `timerFinished` was updated to respect the new toggle-based mute state.