### PR TITLE
This commit adds logic to reset the Timer's mute state when it is sno…

### DIFF
--- a/js/tools.js
+++ b/js/tools.js
@@ -183,7 +183,18 @@ const Tools = (function() {
             if (audio && state.timer.isMuted) {
                 audio.muted = true;
             }
+            // Reset for the next cycle
             state.timer.remainingSeconds = state.timer.totalSeconds;
+            state.timer.endOfCycleSoundPlayed = false;
+
+            // Deactivate mute for the next cycle
+            if (state.timer.isMuted) {
+                state.timer.isMuted = false;
+                const timerMuteBtn = document.getElementById('timerMuteBtn');
+                if (timerMuteBtn) {
+                    timerMuteBtn.classList.remove('active');
+                }
+            }
         } else {
             state.timer.isRunning = false;
             state.timer.alarmPlaying = true;
@@ -220,6 +231,16 @@ const Tools = (function() {
         state.timer.isSnoozing = true;
         state.timer.alarmPlaying = false;
         state.timer.endOfCycleSoundPlayed = false; // Allow sound to play again after snooze
+
+        // Deactivate mute for the next cycle
+        if (state.timer.isMuted) {
+            state.timer.isMuted = false;
+            const timerMuteBtn = document.getElementById('timerMuteBtn');
+            if (timerMuteBtn) {
+                timerMuteBtn.classList.remove('active');
+            }
+        }
+
         startTimer(); // This will set isRunning and update UI correctly
         updateTimerUI(); // Ensure alarm controls are hidden
         updateButtonStates(); // Ensure button text is correct


### PR DESCRIPTION
…ozed or when it repeats in interval mode.

Key changes:
- The `snoozeTimer` function now sets `state.timer.isMuted` to `false` and removes the `.active` class from the mute button.
- The `timerFinished` function, in the case of an interval timer, now also resets the mute state and `endOfCycleSoundPlayed` flag for the next cycle.