### PR TITLE
feat: Make clock and digital display the topmost layer

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,8 @@
         display: block;
         width: 100%;
         height: 100%;
+        position: relative;
+        z-index: 102;
     }
 
     /* Digital clock display */
@@ -59,6 +61,7 @@
         text-align: center;
         line-height: 1.2;
         pointer-events: none;
+        z-index: 102;
     }
 
     #digitalTime {


### PR DESCRIPTION
The circles on the canvas and the digital time display were being obscured by the UI panels, which had a higher z-index.

This change ensures the clock's canvas and the digital display are always the topmost elements by:
- Adding `position: relative` and `z-index: 102` to the `canvas` element's style.
- Adding `z-index: 102` to the `#digitalDisplay` element's style.

This places them above the UI panels, which have a maximum z-index of 101.