### PR TITLE
feat: Add style toggle to timer settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -626,6 +626,13 @@
                     <span class="slider"></span>
                 </label>
             </div>
+            <div class="setting-toggle">
+                <span>Style</span>
+                <label class="switch">
+                    <input type="checkbox" id="timerStyleToggle">
+                    <span class="slider"></span>
+                </label>
+            </div>
         </div>
         <!-- Pomodoro Panel -->
         <div id="pomodoroPanel" class="ui-panel panel-hidden">

--- a/js/tools.js
+++ b/js/tools.js
@@ -7,6 +7,7 @@ const Tools = (function() {
     const timerMinutesInput = document.getElementById('timerMinutes');
     const timerSecondsInput = document.getElementById('timerSeconds');
     const intervalToggle = document.getElementById('intervalToggle');
+    const timerStyleToggle = document.getElementById('timerStyleToggle');
 
     const toggleStopwatchBtn = document.getElementById('toggleStopwatchBtn');
     const lapStopwatchBtn = document.getElementById('lapStopwatch');
@@ -45,6 +46,7 @@ const Tools = (function() {
             remainingSeconds: 0,
             isRunning: false,
             isInterval: false,
+            style: true,
             alarmPlaying: false,
             isMuted: false,
             isSnoozing: false,
@@ -574,6 +576,7 @@ const Tools = (function() {
         toggleTimerBtn.addEventListener('click', toggleTimer);
         resetTimerBtn.addEventListener('click', resetTimer);
         intervalToggle.addEventListener('change', (e) => state.timer.isInterval = e.target.checked);
+        timerStyleToggle.addEventListener('change', (e) => state.timer.style = e.target.checked);
         timerDaysInput.addEventListener('blur', normalizeTimerInputs);
         timerHoursInput.addEventListener('blur', normalizeTimerInputs);
         timerMinutesInput.addEventListener('blur', normalizeTimerInputs);
@@ -667,6 +670,10 @@ const Tools = (function() {
                     state.stopwatch.isRunning = false;
                 }
             }
+
+            // After state is loaded, ensure UI reflects the state
+            intervalToggle.checked = state.timer.isInterval;
+            timerStyleToggle.checked = state.timer.style;
 
             setupAllEventListeners();
             updateLapDisplay();


### PR DESCRIPTION
This commit introduces a new "Style" toggle to the timer settings panel, located directly below the "Repeat" toggle.

The new toggle is wired into the application's state management in `js/tools.js`. A new `style` property has been added to the `state.timer` object, which is updated when the toggle is clicked. The state of the toggle is persisted to `localStorage` and correctly restored on page load.

The default state for the new toggle is "on" (checked), as per the requirements.