### PR TITLE
fix: Correct timer style logic and implement live preview

### DIFF
--- a/js/tools.js
+++ b/js/tools.js
@@ -46,7 +46,7 @@ const Tools = (function() {
             remainingSeconds: 0,
             isRunning: false,
             isInterval: false,
-            style: true,
+            style: false,
             alarmPlaying: false,
             isMuted: false,
             isSnoozing: false,
@@ -113,6 +113,7 @@ const Tools = (function() {
         if (!state.timer.isRunning) {
             state.timer.remainingSeconds = finalTotalSeconds;
         }
+        document.dispatchEvent(new CustomEvent('statechange'));
     }
 
 
@@ -575,8 +576,14 @@ const Tools = (function() {
         // Timer
         toggleTimerBtn.addEventListener('click', toggleTimer);
         resetTimerBtn.addEventListener('click', resetTimer);
-        intervalToggle.addEventListener('change', (e) => state.timer.isInterval = e.target.checked);
-        timerStyleToggle.addEventListener('change', (e) => state.timer.style = e.target.checked);
+        intervalToggle.addEventListener('change', (e) => {
+            state.timer.isInterval = e.target.checked;
+            document.dispatchEvent(new CustomEvent('statechange'));
+        });
+        timerStyleToggle.addEventListener('change', (e) => {
+            state.timer.style = e.target.checked;
+            document.dispatchEvent(new CustomEvent('statechange'));
+        });
         timerDaysInput.addEventListener('blur', normalizeTimerInputs);
         timerHoursInput.addEventListener('blur', normalizeTimerInputs);
         timerMinutesInput.addEventListener('blur', normalizeTimerInputs);


### PR DESCRIPTION
This commit addresses user feedback on the timer style feature.

Key changes:
- Sets the default timer style to "absolute position" (Style OFF) by changing the default value of `state.timer.style` to `false`.
- Implements a live preview for the timer. The timer arcs now update immediately when the user changes the timer inputs (on blur) or toggles the style switch. This is achieved by dispatching a `statechange` event from the relevant event listeners in `js/tools.js`.
- The "absolute position" logic in `js/clock.js` correctly calculates arc progress based on the value's position on a clock face (e.g., 15 minutes is 25% of the circle).