### PR TITLE
feat: Implement Flow mode for color cycling

### DIFF
--- a/index.html
+++ b/index.html
@@ -831,6 +831,13 @@
                         </select>
                     </div>
                     <div class="setting-toggle">
+                        <span>Flow</span>
+                        <label class="switch">
+                            <input type="checkbox" id="flowModeToggle">
+                            <span class="slider"></span>
+                        </label>
+                    </div>
+                    <div class="setting-toggle">
                         <span>Reverse</span>
                         <label class="switch">
                             <input type="checkbox" id="reverseToggle">

--- a/js/clock.js
+++ b/js/clock.js
@@ -12,6 +12,7 @@ const Clock = (function() {
     let animationFrameId = null;
     let resetAnimations = {};
     const animationDuration = 1500; // 1.5 seconds
+    let lastColorChangeMinute = -1;
 
     const hasCompletedCycle = (unit, now, lastNow) => {
         switch (unit) {
@@ -411,6 +412,13 @@ const Clock = (function() {
         }
 
         const now = new Date();
+        if (settings.flowMode) {
+            const minutes = now.getMinutes();
+            if (minutes % 5 === 0 && minutes !== lastColorChangeMinute) {
+                Settings.cycleColorPreset();
+                lastColorChangeMinute = minutes;
+            }
+        }
         const year = now.getFullYear(), month = now.getMonth(), date = now.getDate(), hours = now.getHours(), minutes = now.getMinutes(), seconds = now.getSeconds();
         const dayOfWeek = getDayOfWeek(now);
         const daysInMonth = getDaysInMonth(year, month);

--- a/js/settings.js
+++ b/js/settings.js
@@ -91,6 +91,7 @@ const Settings = (function() {
     function loadSettings() {
         const savedSettings = localStorage.getItem('polarClockSettings');
         const defaultSettings = {
+            flowMode: false,
             showDigitalTime: true,
             showDigitalDate: true,
             showArcEndCircles: true,
@@ -155,6 +156,7 @@ const Settings = (function() {
             paletteSelect.value = ""; // Default to "Select Palette"
         }
         document.getElementById('inverseModeToggle').checked = settings.inverseMode;
+        document.getElementById('flowModeToggle').checked = settings.flowMode;
 
         // New display toggles
         document.getElementById('digitalTimeToggle').checked = settings.showDigitalTime;
@@ -217,6 +219,12 @@ const Settings = (function() {
         });
         document.getElementById('inverseModeToggle').addEventListener('change', (e) => {
             settings.inverseMode = e.target.checked;
+            saveSettings();
+            document.dispatchEvent(new CustomEvent('settings-changed'));
+        });
+
+        document.getElementById('flowModeToggle').addEventListener('change', (e) => {
+            settings.flowMode = e.target.checked;
             saveSettings();
             document.dispatchEvent(new CustomEvent('settings-changed'));
         });
@@ -299,6 +307,19 @@ const Settings = (function() {
         });
     }
 
+    function cycleColorPreset() {
+        const themeNames = Object.keys(colorThemes);
+        const availableThemes = themeNames.filter(name => name !== settings.colorPreset);
+        const randomTheme = availableThemes[Math.floor(Math.random() * availableThemes.length)];
+
+        settings.colorPreset = randomTheme;
+        settings.currentColors = colorThemes[randomTheme];
+
+        saveSettings();
+        applySettingsToUI();
+        document.dispatchEvent(new CustomEvent('settings-changed'));
+    }
+
     return {
         init: function() {
             loadSettings();
@@ -306,6 +327,7 @@ const Settings = (function() {
         },
         get: function() {
             return settings;
-        }
+        },
+        cycleColorPreset: cycleColorPreset
     };
 })();


### PR DESCRIPTION
This commit introduces the "Flow" mode, a new feature that allows the clock's color theme to automatically and randomly cycle through the available presets every 5 minutes.

- Adds a "Flow" toggle switch to the "Visuals & Colors" settings panel.
- Implements the necessary logic in `js/settings.js` to manage the `flowMode` setting and to handle the random color theme selection.
- Updates `js/clock.js` to include a time-based check within the main drawing loop, which triggers the color change at 5-minute intervals when Flow mode is active.