### PR TITLE
feat: Make "Clock Only" the default tool and move to top of list

### DIFF
--- a/index.html
+++ b/index.html
@@ -974,10 +974,10 @@
 
     <footer>
         <div id="tool-select-menu" class="panel-hidden">
+            <button class="tool-select-button" data-mode="clock">Clock Only</button>
             <button class="tool-select-button" data-mode="timer">Timer</button>
             <button class="tool-select-button" data-mode="pomodoro">Pomodoro</button>
             <button class="tool-select-button" data-mode="stopwatch">Stopwatch</button>
-            <button class="tool-select-button" data-mode="clock">Clock Only</button>
         </div>
         <div class="main-nav-buttons">
             <button id="toggleControlsBtn" class="main-nav-button"><i class="ph ph-timer"></i></button>

--- a/js/ui.js
+++ b/js/ui.js
@@ -205,6 +205,11 @@ const UI = (function() {
             const savedState = JSON.parse(localStorage.getItem('polarClockState'));
             if (savedState && savedState.mode) {
                 updateToolPanelVisibility(savedState.mode);
+            } else {
+                // Default to 'clock' mode if no state is saved
+                document.dispatchEvent(new CustomEvent('modechange', {
+                    detail: { mode: 'clock' }
+                }));
             }
         }
     };


### PR DESCRIPTION
This change addresses the user's request to have the "Clock Only" option as the default tool when the application is first opened.

- The "Clock Only" button has been moved to the top of the tool selection menu in `index.html`.
- The `js/ui.js` file has been updated to dispatch a `modechange` event, setting the mode to 'clock' on initial load if no saved state is present in localStorage.