### PR TITLE
Refactor: Move Alarms button to Tools menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -979,12 +979,12 @@
             <button class="tool-select-button" data-mode="pomodoro">Pomodoro</button>
             <button class="tool-select-button" data-mode="stopwatch">Stopwatch</button>
             <button class="tool-select-button" data-mode="meditative">Meditative</button>
+            <button id="goToAlarmsBtn" class="tool-select-button" data-mode="alarms">Alarms</button>
         </div>
         <div class="main-nav-buttons">
             <button id="toggleControlsBtn" class="main-nav-button"><i class="ph ph-timer"></i></button>
             <button id="goToSettingsBtn" class="main-nav-button"><i class="ph ph-gear"></i></button>
             <button id="goToAboutBtn" class="main-nav-button"><i class="ph ph-question"></i></button>
-            <button id="goToAlarmsBtn" class="main-nav-button"><i class="ph ph-bell"></i></button>
         </div>
     </footer>
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -8,7 +8,6 @@ const UI = (function() {
     const navButtons = {
         toggleControls: document.getElementById('toggleControlsBtn'),
         goToSettings: document.getElementById('goToSettingsBtn'),
-        goToAlarms: document.getElementById('goToAlarmsBtn'),
         goToAbout: document.getElementById('goToAboutBtn'),
         backFromSettings: document.getElementById('backToMainFromSettings'),
         backFromAbout: document.getElementById('backToMainFromAbout'),
@@ -160,6 +159,10 @@ const UI = (function() {
             toolSelectButtons.forEach(button => {
                 button.addEventListener('click', () => {
                     const mode = button.dataset.mode;
+                    if (mode === 'alarms') {
+                        window.location.href = 'alarms.html';
+                        return;
+                    }
                     document.dispatchEvent(new CustomEvent('modechange', {
                         detail: { mode: mode }
                     }));
@@ -188,8 +191,6 @@ const UI = (function() {
                     views.pomodoroSettings.style.display = 'none';
                 });
             }
-
-            navButtons.goToAlarms.addEventListener('click', () => { window.location.href = 'alarms.html'; });
 
             pomodoroInfoBtn.addEventListener('click', () => pomodoroInfoModal.classList.remove('hidden'));
             closePomodoroInfoBtn.addEventListener('click', () => pomodoroInfoModal.classList.add('hidden'));


### PR DESCRIPTION
This moves the "Alarms" button from the main navigation bar to within the "Tools" menu, as part of a larger UI refactoring effort.

The following changes were made:
- In `index.html`, the "Alarms" button was moved from the `main-nav-buttons` div to the `tool-select-menu` div.
- The button's class was changed from `main-nav-button` to `tool-select-button` and its text was set to "Alarms".
- In `js/ui.js`, the old event listener for the "Alarms" button was removed.
- A new event listener was added to the `tool-select-button`s to handle the "Alarms" button's click event and navigate to `alarms.html`.