### PR TITLE
feat: Center clock and options button

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,9 +77,9 @@
 
     #optionsBtn {
         position: fixed;
-        bottom: 20px;
+        top: 50%;
         left: 50%;
-        transform: translateX(-50%);
+        transform: translate(-50%, -50%);
         z-index: 200;
     }
 


### PR DESCRIPTION
This commit centers the clock on the screen by removing the right padding from the canvas container. This was previously used to make space for the controls panel on desktop view.

The 'Options' button has been moved from the digital display to the main body of the page and is now positioned in the absolute center of the screen, on top of the clock.