### PR TITLE
Force the application to always start in 'Clock Only' mode.

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -21,6 +21,7 @@ document.addEventListener('DOMContentLoaded', function() {
         if (!appState.tools) {
             appState.tools = {};
         }
+        appState.mode = 'clock'; // Always start in clock mode
     }
 
     // 3. Initialize Modules


### PR DESCRIPTION
The application was previously loading the last used tool from localStorage on startup. This change modifies the initialization logic in `js/main.js` to override the saved mode and always set it to 'clock' on page load. This ensures a consistent starting experience for the user, while still preserving other saved settings for the tools.