### PR TITLE
Refactor initialization to hide tool panels on startup.

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -28,7 +28,7 @@ document.addEventListener('DOMContentLoaded', function() {
     // Clock module needs settings for rendering and the app state for displaying arcs.
     Clock.init(settings, appState);
     // UI module is now independent of the Clock module.
-    UI.init();
+    UI.init(appState);
     // Tools module needs settings for sounds and the initial state for the tools.
     Tools.init(settings, appState.tools);
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -153,7 +153,7 @@ const UI = (function() {
     }
 
     return {
-        init: function() {
+        init: function(appState) {
             const optionsBtn = document.getElementById('optionsBtn');
             const bottomToolbar = document.getElementById('bottom-toolbar');
 
@@ -212,14 +212,12 @@ const UI = (function() {
                 showView(views.pomodoroSettings);
             });
 
-            const savedState = JSON.parse(localStorage.getItem('polarClockState'));
-            if (savedState && savedState.mode) {
-                updateToolPanelVisibility(savedState.mode);
+            // Initialize panel visibility based on the state provided by main.js
+            if (appState && appState.mode) {
+                updateToolPanelVisibility(appState.mode);
             } else {
-                // Default to 'clock' mode if no state is saved
-                document.dispatchEvent(new CustomEvent('modechange', {
-                    detail: { mode: 'clock' }
-                }));
+                // Fallback to clock mode if no state is passed
+                updateToolPanelVisibility('clock');
             }
         }
     };


### PR DESCRIPTION
Previously, the UI component would read the application state from localStorage independently, causing a race condition where the timer panel could be visible on startup even when the application was in 'clock' mode.

This commit refactors the initialization logic to ensure a single source of truth for the application state. `js/main.js` now passes the correctly initialized state to `js/ui.js`, which uses it to set the initial visibility of the UI panels. This prevents the timer panel from being displayed incorrectly on application load.