### PR TITLE
Fix(canvas): Render at native device resolution for high-DPI screens

### DIFF
--- a/js/clock.js
+++ b/js/clock.js
@@ -703,10 +703,21 @@ const Clock = (function() {
         },
         resize: function() {
             if (!canvas) return;
-            canvas.width = canvas.offsetWidth;
-            canvas.height = canvas.offsetHeight;
-            dimensions.centerX = canvas.width / 2;
-            dimensions.centerY = canvas.height / 2;
+
+            const dpr = window.devicePixelRatio || 1;
+            const cssWidth = canvas.offsetWidth;
+            const cssHeight = canvas.offsetHeight;
+
+            canvas.width = cssWidth * dpr;
+            canvas.height = cssHeight * dpr;
+
+            // Reset transform and then scale
+            ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+            // Use the CSS dimensions for layout calculations
+            dimensions.centerX = cssWidth / 2;
+            dimensions.centerY = cssHeight / 2;
+
 
             const baseRadius = Math.min(dimensions.centerX, dimensions.centerY) * 0.9;
             const renderedLineWidth = (6 / 57) * baseRadius;


### PR DESCRIPTION
The clock appeared blurry and low-resolution on mobile devices and other high-DPI (Retina) displays.

This was caused by the canvas being rendered at its standard CSS pixel dimensions, without accounting for the higher physical pixel density of the screen. The browser would then upscale the low-resolution canvas bitmap, leading to blurriness.

The `resize` function in `js/clock.js` has been updated to:
1.  Query the `window.devicePixelRatio` to detect the screen's pixel density.
2.  Scale the canvas's backing store (`canvas.width` and `canvas.height`) by this ratio.
3.  Apply a scaling transform to the rendering context using `ctx.setTransform()`.

This change ensures the canvas is rendered at the full native resolution of the device, resulting in a sharp, crisp display across all screen types.