### PR TITLE
Fix(pomodoro): Prevent one-minute warning from overriding end-of-cycl…

### DIFF
--- a/js/tools.js
+++ b/js/tools.js
@@ -800,7 +800,7 @@ const Tools = (function() {
                     if (pomodoroActions.style.display === 'none') {
                         pomodoroActions.style.display = 'flex';
                     }
-                    if (!state.pomodoro.lastMinuteSoundPlayed) {
+                    if (!state.pomodoro.lastMinuteSoundPlayed && !state.pomodoro.endOfCycleSoundPlayed) {
                         const audio = playSound(settings.timerSound);
                         if (audio) {
                             state.pomodoro.currentAudio = audio;


### PR DESCRIPTION
…e sound

The Pomodoro timer has a feature to play a specific sound at the 58-second mark of each cycle (work, short break, long break). It also has a feature to play a general warning sound when there is one minute remaining.

A race condition existed where the one-minute warning sound could start playing at 60 seconds, and then be interrupted by the end-of-cycle sound at 58 seconds. However, if the timer update function experienced a larger than usual delay (e.g., due to heavy browser load), it was possible for the timer to jump from >60 seconds to <=58 seconds in a single tick. In this scenario, both sound triggers would fire in the same tick, and the one-minute warning could overwrite and silence the intended end-of-cycle sound.

This change prevents the one-minute warning sound from playing if the end-of-cycle sound has already been triggered in the same update tick, ensuring the correct sound is always played.