### PR TITLE
Fixes an issue where the example clock was not visible on the setting…

### DIFF
--- a/js/example-clock.js
+++ b/js/example-clock.js
@@ -241,6 +241,8 @@ const ExampleClock = (function() {
         const cssWidth = container.offsetWidth;
         const cssHeight = container.offsetHeight;
 
+        console.log(`ExampleClock resize: container dimensions are ${cssWidth}x${cssHeight}`);
+
         const size = Math.min(cssWidth, cssHeight);
 
         canvas.width = size * dpr;

--- a/js/ui.js
+++ b/js/ui.js
@@ -154,10 +154,13 @@ const UI = (function() {
             navButtons.goToSettings.addEventListener('click', () => {
                 showView(views.settings);
                 if (window.ExampleClock && typeof window.ExampleClock.resize === 'function') {
-                    // A small delay to ensure the view is visible and has dimensions
-                    setTimeout(() => {
-                        window.ExampleClock.resize();
-                    }, 50);
+                    // Use rAF to ensure the resize is called after the element is visible and sized
+                    requestAnimationFrame(() => {
+                        // A second frame is a robust way to ensure transitions/rendering have completed
+                        requestAnimationFrame(() => {
+                            window.ExampleClock.resize();
+                        });
+                    });
                 }
             });
             navButtons.goToAbout.addEventListener('click', () => {


### PR DESCRIPTION
…s page.

- The `resize` function was being called before the canvas element had its final dimensions.
- Replaces the `setTimeout` with a nested `requestAnimationFrame` in `js/ui.js` to ensure the resize operation happens after the element is fully rendered.