### PR TITLE
Fix: Remove git conflict marker from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1123,10 +1123,7 @@
     <script src="js/tools.js" defer></script>
     <script src="js/settings.js" defer></script>
     <script src="js/example-clock.js" defer></script>
-<<<<<<< HEAD
     <script src="js/time-calculator.js" defer></script>
-=======
->>>>>>> 55969b65753458f16bfc239d4233111b812f16b1
     <script src="js/main.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
A git conflict marker was accidentally left in index.html, causing it to be displayed on the page. This commit removes the marker.