### PR TITLE
Feat: Implement side-by-side settings page layout

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -162,7 +162,6 @@ const UI = (function() {
                         detail: { mode: mode }
                     }));
                     toolSelectMenu.classList.add('panel-hidden'); // Hide menu after selection
-                    bottomToolbar.classList.remove('visible');
                 });
             });
 
@@ -170,12 +169,10 @@ const UI = (function() {
                 controlsContainer.style.display = 'none';
                 toolSelectMenu.classList.add('panel-hidden');
                 settingsPanel.style.display = 'block';
-                bottomToolbar.classList.remove('visible');
             });
             navButtons.goToAbout.addEventListener('click', () => {
                 showView(views.about);
                 initAboutPage();
-                bottomToolbar.classList.remove('visible');
             });
 
             navButtons.backFromAbout.addEventListener('click', () => {


### PR DESCRIPTION
Refactor the settings page to display the main clock and settings controls side-by-side.

This change removes the old settings view, which used a separate example clock, and replaces it with a new settings panel that is always visible on desktop screens. The settings controls now directly affect the main, live clock, providing immediate feedback to the user.

The layout is responsive and falls back to a single-column view on mobile devices.

Additionally, the side panel now retracts when "Clock Only" mode is selected.

Fix(UI): Ensure bottom toolbar visibility is only toggled by the options button.