### PR TITLE
Feat: Implement side-by-side settings page layout

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -166,9 +166,14 @@ const UI = (function() {
             });
 
             navButtons.goToSettings.addEventListener('click', () => {
-                controlsContainer.style.display = 'none';
-                toolSelectMenu.classList.add('panel-hidden');
-                settingsPanel.style.display = 'block';
+                const isSettingsVisible = settingsPanel.style.display === 'block';
+                if (isSettingsVisible) {
+                    settingsPanel.style.display = 'none';
+                } else {
+                    controlsContainer.style.display = 'none';
+                    toolSelectMenu.classList.add('panel-hidden');
+                    settingsPanel.style.display = 'block';
+                }
             });
             navButtons.goToAbout.addEventListener('click', () => {
                 showView(views.about);


### PR DESCRIPTION
Refactor the settings page to display the main clock and settings controls side-by-side.

This change removes the old settings view, which used a separate example clock, and replaces it with a new settings panel that is always visible on desktop screens. The settings controls now directly affect the main, live clock, providing immediate feedback to the user.

The layout is responsive and falls back to a single-column view on mobile devices.

Chore: Add UI interaction improvements
- The side panel now retracts when "Clock Only" mode is selected.
- The settings button now toggles the settings panel visibility.

Fix(UI): Ensure bottom toolbar visibility is only toggled by the options button.