### PR TITLE
feat: Add natural language parsing for time inputs

### DIFF
--- a/time-calc.html
+++ b/time-calc.html
@@ -127,6 +127,54 @@
         document.addEventListener('DOMContentLoaded', () => {
             console.log("Time Calculator script loaded and DOM is ready.");
 
+            // --- LIVE INPUT FORMATTING ---
+            const durationInput = document.getElementById('duration');
+            const time1Input = document.getElementById('time1');
+            const operandInput = document.getElementById('operand');
+
+            if (durationInput) {
+                durationInput.addEventListener('blur', () => {
+                    const value = durationInput.value;
+                    let seconds = parseNaturalTime(value);
+                    if (seconds === null) {
+                        const parts = value.split(':');
+                        if (parts.length === 2) {
+                            const hour = parseInt(parts[0], 10);
+                            const minute = parseInt(parts[1], 10);
+                            if (!isNaN(hour) && !isNaN(minute)) {
+                                seconds = hour * 3600 + minute * 60;
+                            }
+                        }
+                    }
+
+                    if (seconds !== null) {
+                        const formatted = formatSecondsToHHMM(seconds);
+                        if (formatted !== null) {
+                            durationInput.value = formatted;
+                        }
+                    }
+                });
+            }
+
+            function addFormatterListener(element) {
+                if (element) {
+                    element.addEventListener('blur', () => {
+                        const value = element.value;
+                        const seconds = parseHmsToSeconds(value);
+                        if (seconds !== null) {
+                            const formatted = formatSecondsToHms(seconds);
+                            // formatSecondsToHms returns an error string on failure, so check for that
+                            if (!formatted.toLowerCase().includes('error')) {
+                                element.value = formatted;
+                            }
+                        }
+                    });
+                }
+            }
+
+            addFormatterListener(time1Input);
+            addFormatterListener(operandInput);
+
             // --- LOGIC FOR CALCULATOR 1: ADD DURATION TO TIME ---
             const addTimeButton = document.getElementById('calcAddTime');
             const addTimeResultDiv = document.getElementById('addTimeResult');
@@ -145,6 +193,40 @@
                 });
             } else {
                 console.error("Could not find the 'calcAddTime' button.");
+            }
+
+            function parseNaturalTime(timeStr) {
+                if (!timeStr || typeof timeStr !== 'string') return null;
+
+                let totalSeconds = 0;
+                const cleanedStr = timeStr.trim().toLowerCase();
+
+                // This regex finds numbers followed by h, m, or s units.
+                const regex = /(\d+(?:\.\d+)?)\s*(h|hr|hour|hours|m|min|minute|minutes|s|sec|second|seconds)/g;
+
+                let match;
+                let naturalLanguageFound = false;
+                while ((match = regex.exec(cleanedStr)) !== null) {
+                    naturalLanguageFound = true;
+                    const value = parseFloat(match[1]);
+                    const unit = match[2][0]; // h, m, or s
+
+                    if (unit === 'h') {
+                        totalSeconds += value * 3600;
+                    } else if (unit === 'm') {
+                        totalSeconds += value * 60;
+                    } else if (unit === 's') {
+                        totalSeconds += value;
+                    }
+                }
+
+                if (naturalLanguageFound) {
+                    return totalSeconds;
+                }
+
+                // If no natural language was found, return null.
+                // The calling function will be responsible for trying other formats.
+                return null;
             }
 
             function addTime(start, duration, startDay = null) {
@@ -178,14 +260,28 @@
                 const initialTimestamp = initialDate.getTime();
 
                 // 3. Parse Duration and Calculate New Time
-                const durationParts = duration.split(':');
-                if (durationParts.length !== 2) return "Error: Invalid duration format. Use 'hh:mm'.";
-                const durationHour = parseInt(durationParts[0]);
-                const durationMinute = parseInt(durationParts[1]);
+                let durationSeconds = parseNaturalTime(duration);
 
-                if (isNaN(durationHour) || isNaN(durationMinute)) return "Error: Invalid duration values.";
+                if (durationSeconds === null) {
+                    // If natural time parsing fails, try the hh:mm format
+                    const durationParts = duration.split(':');
+                    if (durationParts.length === 2) {
+                        const durationHour = parseInt(durationParts[0], 10);
+                        const durationMinute = parseInt(durationParts[1], 10);
 
-                const durationMillis = (durationHour * 60 + durationMinute) * 60 * 1000;
+                        if (!isNaN(durationHour) && !isNaN(durationMinute)) {
+                            // (hours * 3600) + (minutes * 60)
+                            durationSeconds = (durationHour * 3600) + (durationMinute * 60);
+                        }
+                    }
+                }
+
+                // Check if parsing succeeded one way or another
+                if (durationSeconds === null || isNaN(durationSeconds)) {
+                    return "Error: Invalid duration format. Use 'hh:mm' or a natural language format (e.g., '2h 30m').";
+                }
+
+                const durationMillis = durationSeconds * 1000;
                 const newTime = new Date(initialTimestamp + durationMillis);
 
                 // 4. Calculate Days Passed
@@ -249,9 +345,40 @@
 
 
             function parseHmsToSeconds(timeStr) {
+                // First, try to parse as natural language
+                let seconds = parseNaturalTime(String(timeStr));
+                if (seconds !== null) {
+                    return seconds;
+                }
+
+                // If that fails, try to parse as hh:mm:ss, mm:ss, or a single number (as seconds)
                 const parts = String(timeStr).split(':').map(Number);
-                if (parts.length !== 3 || parts.some(isNaN)) return null;
-                return parts[0] * 3600 + parts[1] * 60 + parts[2];
+                if (!parts.some(isNaN)) {
+                    if (parts.length === 1) {
+                        return parts[0]; // Treat single number as seconds
+                    }
+                    if (parts.length === 2) {
+                        return parts[0] * 60 + parts[1]; // mm:ss
+                    }
+                    if (parts.length === 3) {
+                        return parts[0] * 3600 + parts[1] * 60 + parts[2]; // hh:mm:ss
+                    }
+                }
+
+                // If all parsing fails, return null
+                return null;
+            }
+
+            function formatSecondsToHHMM(totalSeconds) {
+                if (isNaN(totalSeconds) || totalSeconds === null) return null;
+
+                const sign = totalSeconds < 0 ? "-" : "";
+                totalSeconds = Math.abs(Math.round(totalSeconds));
+
+                const hours = Math.floor(totalSeconds / 3600);
+                const minutes = Math.floor((totalSeconds % 3600) / 60);
+
+                return `${sign}${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
             }
 
             function formatSecondsToHms(totalSeconds) {


### PR DESCRIPTION
This commit enhances the time calculator to accept dynamic, natural-language time inputs. Users can now enter values like "2 hours", "90 minutes", or "1h 30m" into the duration and time fields.

Key changes include:
- A new `parseNaturalTime` function that uses regular expressions to convert natural language strings into seconds.
- Integration of this new parser into both the 'Add Duration' and 'Time Arithmetic' calculators, with fallbacks to support the original `hh:mm` and `hh:mm:ss` formats.
- Added `blur` event listeners to the input fields to auto-format the user's input into a standard time format, providing immediate visual feedback.