### PR TITLE
feat: Add word-based number parsing to time calculator

### DIFF
--- a/js/time-calculator.js
+++ b/js/time-calculator.js
@@ -65,11 +65,50 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
+    function wordsToNumbers(text) {
+        const numberWords = {
+            'zero': 0, 'one': 1, 'two': 2, 'three': 3, 'four': 4, 'five': 5, 'six': 6, 'seven': 7, 'eight': 8, 'nine': 9,
+            'ten': 10, 'eleven': 11, 'twelve': 12, 'thirteen': 13, 'fourteen': 14, 'fifteen': 15, 'sixteen': 16, 'seventeen': 17, 'eighteen': 18, 'nineteen': 19,
+            'twenty': 20, 'thirty': 30, 'forty': 40, 'fifty': 50, 'sixty': 60, 'seventy': 70, 'eighty': 80, 'ninety': 90
+        };
+        const multipliers = {
+            'hundred': 100, 'thousand': 1000, 'million': 1000000
+        };
+
+        // This regex is complex, but it finds sequences of number-related words.
+        const numberWordRegex = /\b((?:(?:zero|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty|thirty|forty|fifty|sixty|seventy|eighty|ninety|hundred|thousand|million)[\s-]*)+(?:and[\s-]*)?)+\b/gi;
+
+        return text.replace(numberWordRegex, (match) => {
+            const words = match.toLowerCase().replace(/ and /g, ' ').replace(/-/g, ' ').split(/\s+/).filter(Boolean);
+
+            let total = 0;
+            let currentNumber = 0;
+
+            for (const word of words) {
+                if (numberWords[word] !== undefined) {
+                    currentNumber += numberWords[word];
+                } else if (multipliers[word] !== undefined) {
+                    if (word === 'hundred') {
+                        currentNumber *= multipliers[word];
+                    } else {
+                        total += currentNumber * multipliers[word];
+                        currentNumber = 0;
+                    }
+                }
+            }
+            total += currentNumber;
+            return total > 0 ? total : '';
+        });
+    }
+
     function parseNaturalTime(timeStr) {
         if (!timeStr || typeof timeStr !== 'string') return null;
 
+        // First, convert any number words to digits.
+        const textWithNumbers = wordsToNumbers(timeStr);
+
         let totalSeconds = 0;
-        const cleanedStr = timeStr.trim().toLowerCase();
+        const cleanedStr = textWithNumbers.trim().toLowerCase();
 
         let naturalLanguageFound = false;
 


### PR DESCRIPTION
This commit enhances the time calculator's natural language parsing capabilities to understand numbers written as words (e.g., "five hours", "two hundred minutes").

Key changes include:
- A new `wordsToNumbers` utility function that finds and converts number words within a string into their digit equivalents.
- Integration of this utility into the `parseNaturalTime` function, which now pre-processes all inputs to handle word-based numbers before parsing the time units.
- This feature extends to both the "Add Duration" and "Time Arithmetic" calculators.