### PR TITLE
feat: Replace flow toggle with dropdown for interval selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -988,8 +988,20 @@
                         </select>
                     </div>
                     <div class="setting-item">
-                        <label for="flowModeToggle">Flow</label>
-                        <label class="switch"><input type="checkbox" id="flowModeToggle"><span class="slider"></span></label>
+                        <label for="flowModeSelect">Flow</label>
+                        <select id="flowModeSelect" class="w-full p-2 bg-gray-700 text-white rounded-md" style="max-width: 150px;">
+                            <option value="0">None</option>
+                            <option value="1">1 Min.</option>
+                            <option value="5">5 Min.</option>
+                            <option value="10">10 Min.</option>
+                            <option value="15">15 Min.</option>
+                            <option value="30">30 Min.</option>
+                            <option value="33">BSG</option>
+                            <option value="60">Hour</option>
+                            <option value="360">Quarter</option>
+                            <option value="720">Half</option>
+                            <option value="1440">Day</option>
+                        </select>
                     </div>
                      <div class="setting-item">
                         <label for="reverseToggle">Reverse</label>

--- a/js/clock.js
+++ b/js/clock.js
@@ -13,6 +13,7 @@ const Clock = (function() {
     let resetAnimations = {};
     const animationDuration = 1500; // 1.5 seconds
     let lastColorChangeMinute = -1;
+    let lastFlowChangeTime = null;
 
     const hasCompletedCycle = (unit, now, lastNow) => {
         switch (unit) {
@@ -468,12 +469,18 @@ const Clock = (function() {
         }
 
         const now = new Date();
-        if (settings.flowMode) {
-            const minutes = now.getMinutes();
-            if (minutes % 5 === 0 && minutes !== lastColorChangeMinute) {
-                Settings.cycleColorPreset();
-                lastColorChangeMinute = minutes;
+        if (settings.flowMode && settings.flowMode !== '0') {
+            if (lastFlowChangeTime === null) {
+                lastFlowChangeTime = now.getTime();
             }
+
+            const flowInterval = parseInt(settings.flowMode, 10) * 60 * 1000; // convert minutes to milliseconds
+            if (now.getTime() - lastFlowChangeTime >= flowInterval) {
+                Settings.cycleColorPreset();
+                lastFlowChangeTime = now.getTime();
+            }
+        } else {
+            lastFlowChangeTime = null; // Reset if flow mode is turned off
         }
         const year = now.getFullYear(), month = now.getMonth(), date = now.getDate(), hours = now.getHours(), minutes = now.getMinutes(), seconds = now.getSeconds(), ms = now.getMilliseconds();
         const dayOfWeek = getDayOfWeek(now);

--- a/js/settings.js
+++ b/js/settings.js
@@ -111,7 +111,7 @@ const Settings = (function() {
     function loadSettings() {
         const savedSettings = localStorage.getItem('polarClockSettings');
         const defaultSettings = {
-            flowMode: false,
+            flowMode: '0',
             showArcEndCircles: true,
             inverseMode: false,
             reverseMode: false,
@@ -176,7 +176,7 @@ const Settings = (function() {
         }
         document.getElementById('inverseModeToggle').checked = settings.inverseMode;
         document.getElementById('reverseToggle').checked = settings.reverseMode;
-        document.getElementById('flowModeToggle').checked = settings.flowMode;
+        document.getElementById('flowModeSelect').value = settings.flowMode;
 
         // New display toggles
         document.getElementById('arcEndCirclesToggle').checked = settings.showArcEndCircles;
@@ -248,8 +248,8 @@ const Settings = (function() {
             updateCurrentColors();
         }));
 
-        document.getElementById('flowModeToggle').addEventListener('change', createSettingUpdater(() => {
-            settings.flowMode = document.getElementById('flowModeToggle').checked;
+        document.getElementById('flowModeSelect').addEventListener('change', createSettingUpdater(() => {
+            settings.flowMode = document.getElementById('flowModeSelect').value;
         }));
 
         document.getElementById('arcEndCirclesToggle').addEventListener('change', createSettingUpdater(() => {


### PR DESCRIPTION
Replaces the "Flow" toggle with a dropdown menu, allowing users to select various time intervals for the automatic theme-changing feature.

The changes include:
- Modified index.html to replace the checkbox with a select element.
- Updated settings.js to save and load the selected interval.
- Updated clock.js to implement the theme cycling based on the chosen interval.