### PR TITLE
fix(clock): Use ISO 8601 for week calculations

### DIFF
--- a/js/clock.js
+++ b/js/clock.js
@@ -386,16 +386,17 @@ const Clock = (function() {
     };
 
     const getTotalWeeksInYear = (year) => {
-        const date = new Date(year, 11, 28); // December 28th is always in the last week of the year
-        return getWeekOfYear(date);
+        // ISO 8601 defines Dec 28th as always being in the last week of the year.
+        return getWeekOfYear(new Date(year, 11, 28));
     };
 
     const getWeekOfYear = (date) => {
-        const start = new Date(date.getFullYear(), 0, 1);
-        const diff = (date - start) + ((start.getTimezoneOffset() - date.getTimezoneOffset()) * 60 * 1000);
-        const oneDay = 1000 * 60 * 60 * 24;
-        const day = Math.floor(diff / oneDay);
-        return Math.ceil((day + 1) / 7);
+        // ISO 8601 week number calculation.
+        const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+        const dayNum = d.getUTCDay() || 7;
+        d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+        const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+        return Math.ceil((((d - yearStart) / 86400000) + 1) / 7);
     };
 
     const getLabelText = (unit, now) => {


### PR DESCRIPTION
This commit fixes a visual bug where the 'Week of the Year' and 'Day' arcs on the main clock face could appear misaligned or not update correctly.

The cause was a non-standard implementation for calculating the week of the year and the total number of weeks in a year. This has been replaced with a robust implementation that follows the ISO 8601 standard. This ensures the week-based arcs are always accurate and aligned with standard calendars.